### PR TITLE
fix: monorepo check all projects when release not found

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -92,10 +92,10 @@ func NewReleaseCmd(ctx *appcontext.AppContext) *cobra.Command {
 				switch {
 				case !release:
 					logEvent.Msg("no new release")
-					return nil
+					break
 				case release && ctx.DryRunFlag:
 					logEvent.Msg("dry-run enabled, next release found")
-					return nil
+					break
 				default:
 					logEvent.Msg("new release found")
 

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -92,10 +92,8 @@ func NewReleaseCmd(ctx *appcontext.AppContext) *cobra.Command {
 				switch {
 				case !release:
 					logEvent.Msg("no new release")
-					break
 				case release && ctx.DryRunFlag:
 					logEvent.Msg("dry-run enabled, next release found")
-					break
 				default:
 					logEvent.Msg("new release found")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: 
2. If the PR is unfinished, mark it as such by prefixing its title with "WIP:" https://github.com/s0ders/go-semver-release/blob/main/CONTRIBUTING.md

-->

#### What type of PR is this?

Fix

#### What this PR does / why is it needed:

When generating new releases with a monorepo configuration, if one of the projects listed in the config does not have a new release found, the process stops and other projects are not evaluated for if they have changed.

#### Does this PR introduce a breaking change?

#### Special notes for your reviewer:

**To Reproduce**
1. Create a monorepo configuration with 2 projects
2. Create a commit making a change to the 2nd project listed in the `semver.yaml` configuration
3. Run `go-semver-release release . --config .semver.yaml --dry-run`
4. After the first project detects no new releases found, the process stops and the second project that was changed is never evaluated

**Additional context**

Output when running with changes detected:

```
{"level":"info","new-release":true,"version":"0.3.19","branch":"main","project":"vehicle","message":"new release found"}
{"level":"info","new-release":true,"version":"0.2.17","branch":"main","project":"timeslots","message":"new release found"}
```

Output when running with the first service having no change detected:

```
{"level":"info","new-release":false,"version":"0.3.19","branch":"main","project":"vehicle","message":"no new release"}
```

