### PR TITLE
Version Handling

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -21,6 +21,12 @@ import (
 	"github.com/s0ders/go-semver-release/v6/internal/tag"
 )
 
+const (
+	MessageDryRun       string = "dry-run enabled, next release found"
+	MessageNewRelease   string = "new release found"
+	MessageNoNewRelease string = "no new release"
+)
+
 func NewReleaseCmd(ctx *appcontext.AppContext) *cobra.Command {
 	releaseCmd := &cobra.Command{
 		Use:   "release <REPOSITORY_PATH_OR_URL>",
@@ -82,6 +88,9 @@ func NewReleaseCmd(ctx *appcontext.AppContext) *cobra.Command {
 				logEvent.Bool("new-release", release)
 				logEvent.Str("version", semver.String())
 				logEvent.Str("branch", output.Branch)
+				if output.Error != nil {
+					logEvent.Err(output.Error)
+				}
 
 				if project != "" {
 					logEvent.Str("project", project)
@@ -91,11 +100,11 @@ func NewReleaseCmd(ctx *appcontext.AppContext) *cobra.Command {
 
 				switch {
 				case !release:
-					logEvent.Msg("no new release")
+					logEvent.Msg(MessageNoNewRelease)
 				case release && ctx.DryRunFlag:
-					logEvent.Msg("dry-run enabled, next release found")
+					logEvent.Msg(MessageDryRun)
 				default:
-					logEvent.Msg("new release found")
+					logEvent.Msg(MessageNewRelease)
 
 					err = tagger.TagRepository(repository, semver, commitHash)
 					if err != nil {

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -28,13 +28,19 @@ type cmdOutput struct {
 	Version    string `json:"version"`
 	Project    string `json:"project"`
 	NewRelease bool   `json:"new-release"`
+	Error      string `json:"error"`
 }
+
+var (
+	taggerName  string = "My CI Robot"
+	taggerEmail string = "my-robot@release.ci"
+)
 
 func TestReleaseCmd_ConfigurationAsEnvironmentVariable(t *testing.T) {
 	assert := assertion.New(t)
 	th := NewTestHelper(t)
 
-	err := th.SetFlag(BranchesConfiguration, `[{"name": "master"}]`)
+	err := th.SetFlag(BranchesConfiguration, `[{"name": "main"}]`)
 	checkErr(t, err, "setting branches configuration")
 
 	testRepository := NewTestRepository(t, []string{})
@@ -50,18 +56,15 @@ func TestReleaseCmd_ConfigurationAsEnvironmentVariable(t *testing.T) {
 }
 
 func TestReleaseCmd_ConfigurationAsFile(t *testing.T) {
-	assert := assertion.New(t)
-
-	taggerName := "My CI Robot"
-	taggerEmail := "my-robot@release.ci"
-
 	// Create configuration file
 	cfgContent := []byte(`
 git-name: ` + taggerName + `
 git-email: ` + taggerEmail + `
 tag-prefix: v
 branches:
-  - name: master
+  - name: main
+  - name: beta
+    prerelease: true
   - name: alpha
     prerelease: true
 rules:
@@ -86,26 +89,190 @@ rules:
 	err = os.WriteFile(cfgFilePath, cfgContent, 0o644)
 	checkErr(t, err, "writing configuration file")
 
-	// Create test repository
-	masterCommits := []string{
-		"fix",      // 0.0.1
-		"feat!",    // 1.0.0 (breaking change)
-		"feat",     // 1.1.0
-		"fix",      // 1.1.1
-		"fix",      // 1.1.2
-		"chores",   // 1.1.2
-		"refactor", // 1.1.2
-		"test",     // 1.1.2
-		"ci",       // 1.1.2
-		"feat",     // 1.2.0
-		"perf",     // 1.2.1
-		"revert",   // 1.2.2
-		"style",    // 1.2.2
+	type step struct {
+		branch string
+		cmd    string
+		param  string
+		output *[]cmdOutput
 	}
 
-	alphaCommits := []string{
-		"fix",  // 1.2.3-alpha
-		"feat", // 1.3.0-alpha
+	// Create test steps
+	steps := []step{
+		{"main", "commit", "fix", nil},
+		{"", "release", "", &[]cmdOutput{
+			{
+				Message:    MessageNewRelease,
+				Branch:     "main",
+				Version:    "0.1.0",
+				Project:    "",
+				NewRelease: true,
+				Error:      "",
+			},
+			{
+				Message:    MessageNoNewRelease,
+				Branch:     "beta",
+				Version:    "0.0.0",
+				Project:    "",
+				NewRelease: false,
+				Error:      "remote branch \"refs/remotes/origin/beta\" not found: reference not found",
+			},
+			{
+				Message:    MessageNoNewRelease,
+				Branch:     "alpha",
+				Version:    "0.0.0",
+				Project:    "",
+				NewRelease: false,
+				Error:      "remote branch \"refs/remotes/origin/alpha\" not found: reference not found",
+			},
+		}},
+
+		{"main", "commit", "feat", nil},
+		{"main", "commit", "fix", nil},
+		{"", "release", "", &[]cmdOutput{
+			{
+				Message:    MessageNewRelease,
+				Branch:     "main",
+				Version:    "0.2.0",
+				Project:    "",
+				NewRelease: true,
+				Error:      "",
+			},
+			{
+				Message:    MessageNoNewRelease,
+				Branch:     "beta",
+				Version:    "0.0.0",
+				Project:    "",
+				NewRelease: false,
+				Error:      "remote branch \"refs/remotes/origin/beta\" not found: reference not found",
+			},
+			{
+				Message:    MessageNoNewRelease,
+				Branch:     "alpha",
+				Version:    "0.0.0",
+				Project:    "",
+				NewRelease: false,
+				Error:      "remote branch \"refs/remotes/origin/alpha\" not found: reference not found",
+			},
+		}},
+
+		{"main", "commit", "fix", nil},
+		{"beta", "commit", "feat!", nil},
+		{"", "release", "", &[]cmdOutput{
+			{
+				Message:    MessageNewRelease,
+				Branch:     "main",
+				Version:    "0.2.1",
+				Project:    "",
+				NewRelease: true,
+				Error:      "",
+			},
+			{
+				Message:    MessageNewRelease,
+				Branch:     "beta",
+				Version:    "1.0.0-beta.1",
+				Project:    "",
+				NewRelease: true,
+				Error:      "",
+			},
+			{
+				Message:    MessageNoNewRelease,
+				Branch:     "alpha",
+				Version:    "0.0.0",
+				Project:    "",
+				NewRelease: false,
+				Error:      "remote branch \"refs/remotes/origin/alpha\" not found: reference not found",
+			},
+		}},
+
+		{"main", "commit", "chores", nil},
+		{"beta", "commit", "refactor", nil},
+		{"main", "commit", "test", nil},
+		{"beta", "commit", "ci", nil},
+		{"", "release", "", &[]cmdOutput{
+			{
+				Message:    MessageNoNewRelease,
+				Branch:     "main",
+				Version:    "0.2.1",
+				Project:    "",
+				NewRelease: false,
+				Error:      "",
+			},
+			{
+				Message:    MessageNoNewRelease,
+				Branch:     "beta",
+				Version:    "1.0.0-beta.1",
+				Project:    "",
+				NewRelease: false,
+				Error:      "",
+			},
+			{
+				Message:    MessageNoNewRelease,
+				Branch:     "alpha",
+				Version:    "0.0.0",
+				Project:    "",
+				NewRelease: false,
+				Error:      "remote branch \"refs/remotes/origin/alpha\" not found: reference not found",
+			},
+		}},
+
+		{"alpha", "commit", "perf", nil},
+		{"main", "release", "", &[]cmdOutput{
+			{
+				Message:    MessageNoNewRelease,
+				Branch:     "main",
+				Version:    "0.2.1",
+				Project:    "",
+				NewRelease: false,
+				Error:      "",
+			},
+			{
+				Message:    MessageNoNewRelease,
+				Branch:     "beta",
+				Version:    "1.0.0-beta.1",
+				Project:    "",
+				NewRelease: false,
+				Error:      "",
+			},
+			{
+				Message:    MessageNewRelease,
+				Branch:     "alpha",
+				Version:    "1.0.1-alpha.1",
+				Project:    "",
+				NewRelease: true,
+				Error:      "",
+			},
+		}},
+
+		{"main", "commit", "revert", nil},
+		{"main", "commit", "style", nil},
+		{"alpha", "commit", "feat", nil},
+		{"beta", "commit", "fix", nil},
+		{"", "release", "", &[]cmdOutput{
+			{
+				Message:    MessageNewRelease,
+				Branch:     "main",
+				Version:    "0.2.2",
+				Project:    "",
+				NewRelease: true,
+				Error:      "",
+			},
+			{
+				Message:    MessageNewRelease,
+				Branch:     "beta",
+				Version:    "1.0.0-beta.2",
+				Project:    "",
+				NewRelease: true,
+				Error:      "",
+			},
+			{
+				Message:    MessageNewRelease,
+				Branch:     "alpha",
+				Version:    "1.1.0-alpha.1",
+				Project:    "",
+				NewRelease: true,
+				Error:      "",
+			},
+		}},
 	}
 
 	testRepository, err := gittest.NewRepository()
@@ -116,102 +283,46 @@ rules:
 		checkErr(t, err, "removing repository")
 	}()
 
-	for _, commit := range masterCommits {
-		_, err = testRepository.AddCommit(commit)
-		checkErr(t, err, "creating sample commit")
-	}
-
-	// Creating alpha branch and associated commits
-	err = testRepository.CheckoutBranch("alpha")
-	checkErr(t, err, "checking out alpha branch")
-
-	for _, commit := range alphaCommits {
-		_, err = testRepository.AddCommit(commit)
-		checkErr(t, err, "creating sample commit")
-	}
-
 	th := NewTestHelper(t)
 	err = th.SetFlag("config", cfgFilePath)
 	checkErr(t, err, "setting flags")
 
-	releaseOutput, err := th.ExecuteCommand("release", testRepository.Path)
-	checkErr(t, err, "running release command")
+	for _, step := range steps {
+		switch step.cmd {
+		case "commit":
+			_, err = testRepository.Reference(plumbing.NewBranchReferenceName(step.branch), true)
+			if err == nil {
+				err = testRepository.CheckoutBranch(step.branch, false)
+			} else {
+				err = testRepository.CheckoutBranch(step.branch, true)
+			}
+			checkErr(t, err, "checking out "+step.branch+" branch")
 
-	expectedMasterVersion := "1.2.2"
-	expectedMasterTag := "v" + expectedMasterVersion
-	expectedAlphaVersion := "1.3.0-alpha"
-	expectedAlphaTag := "v" + expectedAlphaVersion
-
-	expectedOutputs := []cmdOutput{
-		{
-			Message:    "new release found",
-			Version:    expectedAlphaVersion,
-			NewRelease: true,
-			Branch:     "alpha",
-		},
-		{
-			Message:    "new release found",
-			Version:    expectedMasterVersion,
-			NewRelease: true,
-			Branch:     "master",
-		},
+			_, err = testRepository.AddCommit(step.param)
+			checkErr(t, err, "creating sample commit")
+		case "release":
+			releaseOutput, err := th.ExecuteCommand("release", testRepository.Path)
+			checkErr(t, err, "running release command")
+			checkRelease(t, testRepository, releaseOutput, *step.output)
+		}
 	}
-	actualOutput := cmdOutput{}
-
-	outputs := make([]string, 0, 2)
-
-	scanner := bufio.NewScanner(bytes.NewReader(releaseOutput))
-	for scanner.Scan() {
-		outputs = append(outputs, scanner.Text())
-	}
-
-	// Checking master
-	err = json.Unmarshal([]byte(outputs[0]), &actualOutput)
-	checkErr(t, err, "unmarshalling master output")
-
-	assert.Contains(expectedOutputs, actualOutput, "releaseCmd output should be equal")
-
-	exists, err := tag.Exists(testRepository.Repository, expectedMasterTag)
-	checkErr(t, err, "checking if master tag exists")
-
-	assert.Equal(true, exists, "master tag not found")
-
-	expectedTagRef, err := testRepository.Tag(expectedMasterTag)
-	checkErr(t, err, "getting master tag ref")
-
-	expectedTagObj, err := testRepository.TagObject(expectedTagRef.Hash())
-	checkErr(t, err, "getting master tag object")
-
-	assert.Equal(taggerName, expectedTagObj.Tagger.Name)
-	assert.Equal(taggerEmail, expectedTagObj.Tagger.Email)
-
-	// Checking alpha
-	err = json.Unmarshal([]byte(outputs[1]), &actualOutput)
-	checkErr(t, err, "unmarshalling alpha output")
-
-	assert.Contains(expectedOutputs, actualOutput, "releaseCmd output should be equal")
-
-	exists, err = tag.Exists(testRepository.Repository, expectedAlphaTag)
-	checkErr(t, err, "checking if alpha tag exists")
-
-	assert.Equal(true, exists, "alpha tag not found")
 }
 
 func TestReleaseCmd_ConfigurationAsFlags(t *testing.T) {
 	assert := assertion.New(t)
 
 	commits := []string{
-		"fix",   // 0.1.0
-		"feat!", // 1.0.0 (breaking change)
-		"feat",  // 1.1.0
-		"fix",   // 1.2.0
+		"fix",
+		"feat!",
+		"feat",
+		"fix",
 	}
 
 	testRepository := NewTestRepository(t, commits)
 
 	th := NewTestHelper(t)
 	err := th.SetFlags(map[string]string{
-		BranchesConfiguration: `[{"name": "master"}]`,
+		BranchesConfiguration: `[{"name": "main"}]`,
 		RulesConfiguration:    `{"minor": ["feat", "fix"]}`,
 	})
 	checkErr(t, err, "setting flags")
@@ -219,13 +330,13 @@ func TestReleaseCmd_ConfigurationAsFlags(t *testing.T) {
 	output, err := th.ExecuteCommand("release", testRepository.Path)
 	checkErr(t, err, "executing command")
 
-	expectedVersion := "1.2.0"
+	expectedVersion := "0.1.0"
 	expectedTag := "v" + expectedVersion
 	expectedOut := cmdOutput{
-		Message:    "new release found",
+		Message:    MessageNewRelease,
 		Version:    expectedVersion,
 		NewRelease: true,
-		Branch:     "master",
+		Branch:     "main",
 	}
 	actualOut := cmdOutput{}
 
@@ -235,28 +346,28 @@ func TestReleaseCmd_ConfigurationAsFlags(t *testing.T) {
 	assert.Equal(expectedOut, actualOut, "releaseCmd output should be equal")
 
 	exists, err := tag.Exists(testRepository.Repository, expectedTag)
-	checkErr(t, err, "checking if master tag exists")
+	checkErr(t, err, "checking if main tag exists")
 
-	assert.Equal(true, exists, "master tag not found")
+	assert.Equal(true, exists, "main tag not found")
 }
 
 func TestReleaseCmd_LocalRelease(t *testing.T) {
 	assert := assertion.New(t)
 
 	commits := []string{
-		"fix",      // 0.0.1
-		"feat!",    // 1.0.0 (breaking change)
-		"feat",     // 1.1.0
-		"fix",      // 1.1.1
-		"fix",      // 1.1.2
-		"chores",   // 1.1.2
-		"refactor", // 1.1.2
-		"test",     // 1.1.2
-		"ci",       // 1.1.2
-		"feat",     // 1.2.0
-		"perf",     // 1.2.1
-		"revert",   // 1.2.2
-		"style",    // 1.2.2
+		"fix",
+		"feat!",
+		"feat",
+		"fix",
+		"fix",
+		"chores",
+		"refactor",
+		"test",
+		"ci",
+		"feat",
+		"perf",
+		"revert",
+		"style",
 	}
 
 	testRepository := NewTestRepository(t, commits)
@@ -267,19 +378,19 @@ func TestReleaseCmd_LocalRelease(t *testing.T) {
 	}()
 
 	th := NewTestHelper(t)
-	err := th.SetFlag(BranchesConfiguration, `[{"name": "master"}]`)
+	err := th.SetFlag(BranchesConfiguration, `[{"name": "main"}]`)
 	checkErr(t, err, "setting flags")
 
 	out, err := th.ExecuteCommand("release", testRepository.Path)
 	checkErr(t, err, "executing command")
 
-	expectedVersion := "1.2.2"
+	expectedVersion := "0.1.0"
 	expectedTag := "v" + expectedVersion
 	expectedOut := cmdOutput{
-		Message:    "new release found",
+		Message:    MessageNewRelease,
 		Version:    expectedVersion,
 		NewRelease: true,
-		Branch:     "master",
+		Branch:     "main",
 	}
 	actualOut := cmdOutput{}
 
@@ -298,26 +409,26 @@ func TestReleaseCmd_RemoteRelease(t *testing.T) {
 	assert := assertion.New(t)
 
 	commits := []string{
-		"fix",      // 0.0.1
-		"feat!",    // 1.0.0 (breaking change)
-		"feat",     // 1.1.0
-		"fix",      // 1.1.1
-		"fix",      // 1.1.2
-		"chores",   // 1.1.2
-		"refactor", // 1.1.2
-		"test",     // 1.1.2
-		"ci",       // 1.1.2
-		"feat",     // 1.2.0
-		"perf",     // 1.2.1
-		"revert",   // 1.2.2
-		"style",    // 1.2.2
+		"fix",
+		"feat!",
+		"feat",
+		"fix",
+		"fix",
+		"chores",
+		"refactor",
+		"test",
+		"ci",
+		"feat",
+		"perf",
+		"revert",
+		"style",
 	}
 
 	testRepository := NewTestRepository(t, commits)
 
 	th := NewTestHelper(t)
 	err := th.SetFlags(map[string]string{
-		BranchesConfiguration:    `[{"name": "master"}]`,
+		BranchesConfiguration:    `[{"name": "main"}]`,
 		RemoteNameConfiguration:  "origin",
 		AccessTokenConfiguration: "",
 	})
@@ -326,13 +437,13 @@ func TestReleaseCmd_RemoteRelease(t *testing.T) {
 	out, err := th.ExecuteCommand("release", testRepository.Path)
 	checkErr(t, err, "executing command")
 
-	expectedVersion := "1.2.2"
+	expectedVersion := "0.1.0"
 	expectedTag := "v" + expectedVersion
 	expectedOut := cmdOutput{
-		Message:    "new release found",
+		Message:    MessageNewRelease,
 		Version:    expectedVersion,
 		NewRelease: true,
-		Branch:     "master",
+		Branch:     "main",
 	}
 	actualOut := cmdOutput{}
 
@@ -353,27 +464,27 @@ func TestReleaseCmd_MultiBranchRelease(t *testing.T) {
 	testRepository, err := gittest.NewRepository()
 	checkErr(t, err, "creating sample repository")
 
-	// Create commits on master
-	masterCommits := []string{
-		"fix",      // 0.0.1
-		"feat!",    // 1.0.0 (breaking change)
-		"feat",     // 1.1.0
-		"fix",      // 1.1.1
-		"fix",      // 1.1.2
-		"chores",   // 1.1.2
-		"refactor", // 1.1.2
-		"test",     // 1.1.2
-		"ci",       // 1.1.2
-		"feat",     // 1.2.0
-		"perf",     // 1.2.1
-		"revert",   // 1.2.2
-		"style",    // 1.2.2
+	// Create commits on main
+	mainCommits := []string{
+		"fix",
+		"feat!",
+		"feat",
+		"fix",
+		"fix",
+		"chores",
+		"refactor",
+		"test",
+		"ci",
+		"feat",
+		"perf",
+		"revert",
+		"style",
 	}
 
-	if len(masterCommits) != 0 {
-		for _, commit := range masterCommits {
+	if len(mainCommits) != 0 {
+		for _, commit := range mainCommits {
 			_, err = testRepository.AddCommit(commit)
-			checkErr(t, err, "creating sample commit on master")
+			checkErr(t, err, "creating sample commit on main")
 		}
 	}
 
@@ -398,9 +509,9 @@ func TestReleaseCmd_MultiBranchRelease(t *testing.T) {
 	checkErr(t, err, "checking out to branch rc")
 
 	rcCommits := []string{
-		"feat!", // 2.0.0
-		"feat",  // 2.1.0
-		"perf",  // 2.1.1
+		"feat!",
+		"feat",
+		"perf",
 	}
 
 	for _, commit := range rcCommits {
@@ -409,7 +520,7 @@ func TestReleaseCmd_MultiBranchRelease(t *testing.T) {
 	}
 
 	th := NewTestHelper(t)
-	err = th.SetFlag(BranchesConfiguration, `[{"name": "master"}, {"name": "rc", "prerelease": true}]`)
+	err = th.SetFlag(BranchesConfiguration, `[{"name": "main"}, {"name": "rc", "prerelease": true}]`)
 	checkErr(t, err, "setting flags")
 
 	out, err := th.ExecuteCommand("release", testRepository.Path)
@@ -418,14 +529,14 @@ func TestReleaseCmd_MultiBranchRelease(t *testing.T) {
 	i := 0
 	expectedOutputs := []cmdOutput{
 		{
-			Message:    "new release found",
-			Version:    "1.2.2",
+			Message:    MessageNewRelease,
+			Version:    "0.1.0",
 			NewRelease: true,
-			Branch:     "master",
+			Branch:     "main",
 		},
 		{
-			Message:    "new release found",
-			Version:    "2.1.1-rc",
+			Message:    MessageNewRelease,
+			Version:    "1.0.0-rc.1",
 			NewRelease: true,
 			Branch:     "rc",
 		},
@@ -441,7 +552,7 @@ func TestReleaseCmd_MultiBranchRelease(t *testing.T) {
 		err = json.Unmarshal(rawOutput, &actualOutput)
 		checkErr(t, err, "unmarshalling output")
 
-		assert.Contains(expectedOutputs, actualOutput)
+		assert.Equal(expectedOutputs[i], actualOutput)
 		i++
 	}
 
@@ -454,10 +565,10 @@ func TestReleaseCmd_ReleaseWithMetadata(t *testing.T) {
 	metadata := "foobarbaz"
 
 	commits := []string{
-		"fix",   // 0.0.1
-		"feat!", // 1.0.0 (breaking change)
-		"feat",  // 1.1.0
-		"fix",   // 1.1.1
+		"fix",
+		"feat!",
+		"feat",
+		"fix",
 	}
 
 	testRepository := NewTestRepository(t, commits)
@@ -465,20 +576,20 @@ func TestReleaseCmd_ReleaseWithMetadata(t *testing.T) {
 	th := NewTestHelper(t)
 	err := th.SetFlags(map[string]string{
 		BuildMetadataConfiguration: metadata,
-		BranchesConfiguration:      `[{"name": "master"}]`,
+		BranchesConfiguration:      `[{"name": "main"}]`,
 	})
 	checkErr(t, err, "setting flags")
 
 	out, err := th.ExecuteCommand("release", testRepository.Path)
 	checkErr(t, err, "executing command")
 
-	expectedVersion := "1.1.1" + "+" + metadata
+	expectedVersion := "0.1.0" + "+" + metadata
 	expectedTag := "v" + expectedVersion
 	expectedOut := cmdOutput{
-		Message:    "new release found",
+		Message:    MessageNewRelease,
 		Version:    expectedVersion,
 		NewRelease: true,
-		Branch:     "master",
+		Branch:     "main",
 	}
 	actualOut := cmdOutput{}
 
@@ -497,27 +608,27 @@ func TestReleaseCmd_PrereleaseBranch(t *testing.T) {
 	assert := assertion.New(t)
 
 	commits := []string{
-		"fix",   // 0.0.1
-		"feat!", // 1.0.0 (breaking change)
-		"feat",  // 1.1.0
-		"fix",   // 1.1.1
+		"fix",
+		"feat!",
+		"feat",
+		"fix",
 	}
 
 	testRepository := NewTestRepository(t, commits)
 
 	th := NewTestHelper(t)
-	err := th.SetFlag(BranchesConfiguration, `[{"name": "master", "prerelease": true}]`)
+	err := th.SetFlag(BranchesConfiguration, `[{"name": "main", "prerelease": true}]`)
 	checkErr(t, err, "setting flags")
 	out, err := th.ExecuteCommand("release", testRepository.Path)
 	checkErr(t, err, "executing command")
 
-	expectedVersion := "1.1.1-master"
+	expectedVersion := "0.1.0-main.1"
 	expectedTag := "v" + expectedVersion
 	expectedOut := cmdOutput{
-		Message:    "new release found",
+		Message:    MessageNewRelease,
 		Version:    expectedVersion,
 		NewRelease: true,
-		Branch:     "master",
+		Branch:     "main",
 	}
 	actualOut := cmdOutput{}
 
@@ -536,26 +647,26 @@ func TestReleaseCmd_DryRunRelease(t *testing.T) {
 	assert := assertion.New(t)
 
 	commits := []string{
-		"fix",   // 0.0.1
-		"feat!", // 1.0.0 (breaking change)
+		"fix",
+		"feat!",
 	}
 
 	testRepository := NewTestRepository(t, commits)
 
 	th := NewTestHelper(t)
 	err := th.SetFlags(map[string]string{
-		BranchesConfiguration: `[{"name": "master"}]`,
+		BranchesConfiguration: `[{"name": "main"}]`,
 		DryRunConfiguration:   `true`,
 	})
 	checkErr(t, err, "setting flags")
 	out, err := th.ExecuteCommand("release", testRepository.Path)
 	checkErr(t, err, "executing command")
 
-	expectedVersion := "1.0.0"
+	expectedVersion := "0.1.0"
 	expectedTag := expectedVersion
 	expectedOut := cmdOutput{
-		Message:    "dry-run enabled, next release found",
-		Branch:     "master",
+		Message:    MessageDryRun,
+		Branch:     "main",
 		Version:    expectedVersion,
 		NewRelease: true,
 	}
@@ -578,16 +689,16 @@ func TestReleaseCmd_ReleaseNoNewVersion(t *testing.T) {
 	testRepository := NewTestRepository(t, []string{})
 
 	th := NewTestHelper(t)
-	err := th.SetFlag(BranchesConfiguration, `[{"name": "master"}]`)
+	err := th.SetFlag(BranchesConfiguration, `[{"name": "main"}]`)
 	checkErr(t, err, "setting flags")
 
 	out, err := th.ExecuteCommand("release", testRepository.Path)
 	checkErr(t, err, "executing command")
 
 	expectedOut := cmdOutput{
-		Message:    "no new release",
+		Message:    MessageNoNewRelease,
 		NewRelease: false,
-		Branch:     "master",
+		Branch:     "main",
 		Version:    "0.0.0",
 	}
 	actualOut := cmdOutput{}
@@ -632,7 +743,7 @@ func TestReleaseCmd_ReadOnlyGitHubOutput(t *testing.T) {
 	testRepository := NewTestRepository(t, []string{})
 
 	th := NewTestHelper(t)
-	err = th.SetFlag(BranchesConfiguration, `[{"name": "master"}]`)
+	err = th.SetFlag(BranchesConfiguration, `[{"name": "main"}]`)
 	checkErr(t, err, "setting flags")
 
 	_, err = th.ExecuteCommand("release", testRepository.Path)
@@ -643,7 +754,7 @@ func TestReleaseCmd_InvalidRepositoryPath(t *testing.T) {
 	assert := assertion.New(t)
 
 	th := NewTestHelper(t)
-	_ = th.SetFlag(BranchesConfiguration, `[{"name": "master"}]`)
+	_ = th.SetFlag(BranchesConfiguration, `[{"name": "main"}]`)
 	_, err := th.ExecuteCommand("release", "./does/not/exist")
 
 	assert.ErrorContains(err, "cloning Git repository", "should have failed trying to open inexisting Git repository")
@@ -670,7 +781,7 @@ func TestReleaseCmd_RepositoryWithNoHead(t *testing.T) {
 	}
 
 	th := NewTestHelper(t)
-	err = th.SetFlag(BranchesConfiguration, `[{"name": "master"}]`)
+	err = th.SetFlag(BranchesConfiguration, `[{"name": "main"}]`)
 	checkErr(t, err, "setting flags")
 
 	_, err = th.ExecuteCommand("release", tempDirPath)
@@ -682,15 +793,15 @@ func TestReleaseCmd_CustomRules(t *testing.T) {
 	assert := assertion.New(t)
 
 	commits := []string{
-		"fix",  // 0.1.0 (with custom rule)
-		"feat", // 0.2.0
+		"fix",
+		"feat",
 	}
 
 	testRepository := NewTestRepository(t, commits)
 
 	th := NewTestHelper(t)
 	err := th.SetFlags(map[string]string{
-		BranchesConfiguration: `[{"name": "master"}]`,
+		BranchesConfiguration: `[{"name": "main"}]`,
 		RulesConfiguration:    `{"minor": ["feat", "fix"]}`,
 	})
 	checkErr(t, err, "setting flags")
@@ -698,13 +809,13 @@ func TestReleaseCmd_CustomRules(t *testing.T) {
 	out, err := th.ExecuteCommand("release", testRepository.Path)
 	checkErr(t, err, "executing command")
 
-	expectedVersion := "0.2.0"
+	expectedVersion := "0.1.0"
 	expectedTag := "v" + expectedVersion
 	expectedOut := cmdOutput{
-		Message:    "new release found",
+		Message:    MessageNewRelease,
 		Version:    expectedVersion,
 		NewRelease: true,
-		Branch:     "master",
+		Branch:     "main",
 	}
 	actualOut := cmdOutput{}
 
@@ -748,7 +859,7 @@ func TestReleaseCmd_Monorepo(t *testing.T) {
 
 	th := NewTestHelper(t)
 	err = th.SetFlags(map[string]string{
-		BranchesConfiguration: `[{"name": "master"}]`,
+		BranchesConfiguration: `[{"name": "main"}]`,
 		MonorepoConfiguration: `[{"name": "foo", "path": "foo"}, {"name": "bar", "path": "bar"}]`,
 	})
 	checkErr(t, err, "setting flags")
@@ -759,17 +870,17 @@ func TestReleaseCmd_Monorepo(t *testing.T) {
 	i := 0
 	expectedOutputs := []cmdOutput{
 		{
-			Message:    "new release found",
-			Version:    "0.1.1",
+			Message:    MessageNewRelease,
+			Version:    "0.1.0",
 			NewRelease: true,
-			Branch:     "master",
+			Branch:     "main",
 			Project:    "foo",
 		},
 		{
-			Message:    "new release found",
-			Version:    "1.0.2",
+			Message:    MessageNewRelease,
+			Version:    "0.1.0",
 			NewRelease: true,
-			Branch:     "master",
+			Branch:     "main",
 			Project:    "bar",
 		},
 	}
@@ -812,7 +923,7 @@ func TestReleaseCmd_Monorepo_MixedRelease(t *testing.T) {
 
 	th := NewTestHelper(t)
 	err = th.SetFlags(map[string]string{
-		BranchesConfiguration: `[{"name": "master"}]`,
+		BranchesConfiguration: `[{"name": "main"}]`,
 		MonorepoConfiguration: `[{"name": "foo", "path": "foo"}, {"name": "bar", "path": "bar"}]`,
 	})
 	checkErr(t, err, "setting flags")
@@ -823,17 +934,17 @@ func TestReleaseCmd_Monorepo_MixedRelease(t *testing.T) {
 	i := 0
 	expectedOutputs := []cmdOutput{
 		{
-			Message:    "no new release",
+			Message:    MessageNoNewRelease,
 			Version:    "0.0.0",
 			NewRelease: false,
-			Branch:     "master",
+			Branch:     "main",
 			Project:    "foo",
 		},
 		{
-			Message:    "new release found",
-			Version:    "1.0.2",
+			Message:    MessageNewRelease,
+			Version:    "0.1.0",
 			NewRelease: true,
-			Branch:     "master",
+			Branch:     "main",
 			Project:    "bar",
 		},
 	}
@@ -1027,6 +1138,43 @@ func ExecuteCommand(cmd *cobra.Command, args ...string) ([]byte, error) {
 	cmd.SetArgs(args)
 	err := cmd.Execute()
 	return output.Bytes(), err
+}
+
+func checkRelease(t *testing.T, r *gittest.TestRepository, output []byte, expected []cmdOutput) {
+	assert := assertion.New(t)
+
+	parts := make([]string, 0, len(expected))
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		parts = append(parts, scanner.Text())
+	}
+
+	for i, part := range parts {
+		expectedOutput := expected[i]
+		actualOutput := cmdOutput{}
+		err := json.Unmarshal([]byte(part), &actualOutput)
+		checkErr(t, err, "unmarshalling main output")
+
+		assert.Equal(expectedOutput, actualOutput, "releaseCmd output should be equal")
+
+		if actualOutput.NewRelease {
+			expectedTag := "v" + actualOutput.Version
+
+			exists, err := tag.Exists(r.Repository, expectedTag)
+			checkErr(t, err, "checking if main tag exists")
+
+			assert.Equal(true, exists, "main tag not found")
+
+			expectedTagRef, err := r.Tag(expectedTag)
+			checkErr(t, err, "getting main tag ref")
+
+			expectedTagObj, err := r.TagObject(expectedTagRef.Hash())
+			checkErr(t, err, "getting main tag object")
+
+			assert.Equal(taggerName, expectedTagObj.Tagger.Name)
+			assert.Equal(taggerEmail, expectedTagObj.Tagger.Email)
+		}
+	}
 }
 
 func checkErr(t *testing.T, err error, message string) {

--- a/internal/branch/branch.go
+++ b/internal/branch/branch.go
@@ -4,6 +4,8 @@ package branch
 import (
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 )
 
 var (
@@ -50,6 +52,20 @@ func Unmarshall(input []map[string]any) ([]Branch, error) {
 
 		branches[i] = branch
 	}
+
+	// Sort branches to ensure processing the branches in the right order.
+	slices.SortFunc(branches, func(b1, b2 Branch) int {
+		switch {
+		case !b2.Prerelease && b1.Prerelease:
+			return 1
+		case b2.Prerelease && !b1.Prerelease:
+			return -1
+		case b1.Prerelease && b2.Prerelease:
+			return strings.Compare(b2.Name, b1.Name)
+		default:
+			return 0
+		}
+	})
 
 	return branches, nil
 }

--- a/internal/branch/branch_test.go
+++ b/internal/branch/branch_test.go
@@ -9,9 +9,14 @@ import (
 func TestBranch_Unmarshall(t *testing.T) {
 	assert := assertion.New(t)
 
-	have := []map[string]any{{"name": "main"}, {"name": "alpha", "prerelease": true}}
+	have := []map[string]any{
+		{"name": "alpha", "prerelease": true},
+		{"name": "main"},
+		{"name": "beta", "prerelease": true},
+	}
 	want := []Branch{
 		{Name: "main"},
+		{Name: "beta", Prerelease: true},
 		{Name: "alpha", Prerelease: true},
 	}
 
@@ -20,7 +25,7 @@ func TestBranch_Unmarshall(t *testing.T) {
 		t.Fatalf("unmarshalling branches: %s", err)
 	}
 
-	assert.Equal(want, branches)
+	assert.Equal(want, branches, "should return all branches in order")
 }
 
 func TestBranch_UnmarshallErrors(t *testing.T) {

--- a/internal/gittest/gittest.go
+++ b/internal/gittest/gittest.go
@@ -11,9 +11,11 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/memory"
 )
 
 const sampleFile = "sample.txt"
@@ -42,6 +44,16 @@ func NewRepository() (*TestRepository, error) {
 	repository, err := git.PlainInit(path, false)
 	if err != nil {
 		return testRepository, fmt.Errorf("initializing repository: %s", err)
+	}
+
+	err = repository.Storer.SetReference(
+		plumbing.NewSymbolicReference(
+			plumbing.HEAD,
+			plumbing.NewBranchReferenceName("main"),
+		),
+	)
+	if err != nil {
+		return testRepository, fmt.Errorf("create main branch: %s", err)
 	}
 
 	testRepository.Repository = repository
@@ -86,18 +98,14 @@ func NewRepository() (*TestRepository, error) {
 	return testRepository, err
 }
 
-// Clone clones the current TestRepository to a temporary directory and returns the clone of that repository. This
+// Clone clones the current TestRepository to memory and returns the clone of that repository. This
 // method is useful when testing on repository that are expected to have a configured remote.
 func (r *TestRepository) Clone() (*TestRepository, error) {
 	testRepository := &TestRepository{}
 
-	tempDir, err := os.MkdirTemp("", "*")
-	if err != nil {
-		return nil, fmt.Errorf("creating temporary directory: %w", err)
-	}
-
-	testRepository.Path = tempDir
-	testRepository.Repository, err = git.PlainClone(tempDir, false, &git.CloneOptions{
+	var err error
+	testRepository.Path = "."
+	testRepository.Repository, err = git.Clone(memory.NewStorage(), memfs.New(), &git.CloneOptions{
 		URL:      r.Path,
 		Progress: io.Discard,
 	})
@@ -106,6 +114,15 @@ func (r *TestRepository) Clone() (*TestRepository, error) {
 	}
 
 	return testRepository, nil
+}
+
+// Add commit to specified branch
+func (r *TestRepository) AddCommitToBranch(commitType string, branch string) (plumbing.Hash, error) {
+	err := r.CheckoutBranch(branch, false)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("checkout branch: %w", err)
+	}
+	return r.AddCommit(commitType)
 }
 
 // AddCommit adds a new commit with a given conventional commit type to the underlying Git repository.
@@ -117,14 +134,17 @@ func (r *TestRepository) AddCommit(commitType string) (plumbing.Hash, error) {
 		return commitHash, fmt.Errorf("fetching worktree: %w", err)
 	}
 
-	commitFilePath := filepath.Join(r.Path, sampleFile)
+	newFile, err := worktree.Filesystem.Create(sampleFile)
+	if err != nil {
+		return commitHash, fmt.Errorf("creating commit file: %w", err)
+	}
 
-	err = os.WriteFile(commitFilePath, []byte(strconv.Itoa(rand.IntN(10000))), 0o644)
+	_, err = newFile.Write([]byte(strconv.Itoa(rand.IntN(10000))))
 	if err != nil {
 		return commitHash, fmt.Errorf("writing commit file: %w", err)
 	}
 
-	_, err = worktree.Add(sampleFile)
+	_, err = worktree.Add(newFile.Name())
 	if err != nil {
 		return commitHash, fmt.Errorf("adding commit file to worktree: %w", err)
 	}
@@ -162,20 +182,25 @@ func (r *TestRepository) AddCommitWithSpecificFile(commitType, filePath string) 
 		return commitHash, fmt.Errorf("fetching worktree: %w", err)
 	}
 
-	commitFilePath := filepath.Clean(filepath.Join(r.Path, filePath))
+	commitFilePath := filepath.Clean(filePath)
 	dirs := filepath.Dir(commitFilePath)
 
-	err = os.MkdirAll(dirs, os.ModePerm)
+	err = worktree.Filesystem.MkdirAll(dirs, os.ModePerm)
 	if err != nil {
 		return commitHash, fmt.Errorf("creating parent directory: %w", err)
 	}
 
-	err = os.WriteFile(commitFilePath, []byte(strconv.Itoa(rand.IntN(10000))), 0o644)
+	newFile, err := worktree.Filesystem.Create(commitFilePath)
+	if err != nil {
+		return commitHash, fmt.Errorf("creating commit file: %w", err)
+	}
+
+	_, err = newFile.Write([]byte(strconv.Itoa(rand.IntN(10000))))
 	if err != nil {
 		return commitHash, fmt.Errorf("writing commit file: %w", err)
 	}
 
-	_, err = worktree.Add(filepath.Clean(filePath))
+	_, err = worktree.Add(filePath)
 	if err != nil {
 		return commitHash, fmt.Errorf("adding commit file to worktree: %w", err)
 	}
@@ -205,6 +230,15 @@ func (r *TestRepository) AddCommitWithSpecificFile(commitType, filePath string) 
 	return commitHash, nil
 }
 
+// Adds tag to a specific branch
+func (r *TestRepository) AddTagToBranch(tagName string, branch string) error {
+	ref, err := r.Reference(plumbing.NewBranchReferenceName(branch), true)
+	if err != nil {
+		return err
+	}
+	return r.AddTag(tagName, ref.Hash())
+}
+
 // AddTag adds a new tag to the underlying Git repository with a given name and pointing to a given hash.
 func (r *TestRepository) AddTag(tagName string, hash plumbing.Hash) error {
 	commit, err := r.CommitObject(hash)
@@ -231,24 +265,21 @@ func (r *TestRepository) Remove() error {
 	return os.RemoveAll(r.Path)
 }
 
-// CheckoutBranch creates a new branch with the given name and checkout to it.
-func (r *TestRepository) CheckoutBranch(name string) error {
-	head, err := r.Head()
-	if err != nil {
-		return err
-	}
+// CheckoutBranch checkouts a branch or creates a new branch with the given name and checkout to it.
+func (r *TestRepository) CheckoutBranch(name string, create bool) error {
+	branch := plumbing.NewBranchReferenceName(name)
 
-	refName := "refs/heads/" + name
-	ref := plumbing.NewHashReference(plumbing.ReferenceName(refName), head.Hash())
+	if create {
+		head, err := r.Head()
+		if err != nil {
+			return err
+		}
 
-	err = r.Storer.SetReference(ref)
-	if err != nil {
-		return err
-	}
-
-	branchCoOpts := &git.CheckoutOptions{
-		Branch: plumbing.ReferenceName(refName),
-		Force:  true,
+		ref := plumbing.NewHashReference(branch, head.Hash())
+		err = r.Storer.SetReference(ref)
+		if err != nil {
+			return err
+		}
 	}
 
 	worktree, err := r.Worktree()
@@ -256,7 +287,10 @@ func (r *TestRepository) CheckoutBranch(name string) error {
 		return err
 	}
 
-	err = worktree.Checkout(branchCoOpts)
+	err = worktree.Checkout(&git.CheckoutOptions{
+		Branch: branch,
+		Force:  true,
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -45,6 +44,13 @@ type ComputeNewSemverOutput struct {
 	Branch     string
 	CommitHash plumbing.Hash
 	NewRelease bool
+	Error      error
+}
+
+type TagInfo struct {
+	Semver *semver.Version
+	Name   string
+	Commit *object.Commit
 }
 
 // Run execute a parser on a repository and analyze the given branches and projects contained inside the given
@@ -52,19 +58,24 @@ type ComputeNewSemverOutput struct {
 func (p *Parser) Run(ctx context.Context, repository *git.Repository) ([]ComputeNewSemverOutput, error) {
 	var output []ComputeNewSemverOutput
 
+	// This map holds the latest version for each channel.
+	// This is to be able to determine lower tier channel versions based of a potential new higher tier version bumped in this run.
+	semverMap := make(map[string]*TagInfo)
 	for _, gitBranch := range p.ctx.Branches {
-		err := p.checkoutBranch(repository, gitBranch.Name)
-		if err != nil {
-			return output, fmt.Errorf("checking out to gitBranch %q: %w", gitBranch.Name, err)
-		}
+		branchErr := p.checkoutBranch(repository, gitBranch.Name)
 
 		if len(p.ctx.Projects) == 0 {
-			computerNewSemverOutput, err := p.ComputeNewSemver(repository, monorepo.Project{}, gitBranch)
-			if err != nil {
-				return nil, fmt.Errorf("computing new semver: %w", err)
+			var result ComputeNewSemverOutput
+			if branchErr != nil {
+				result = createResultWithError(gitBranch.Name, branchErr)
+			} else {
+				var err error
+				result, err = p.ComputeNewSemver(repository, monorepo.Project{}, gitBranch, semverMap)
+				if err != nil {
+					return nil, fmt.Errorf("computing new semver: %w", err)
+				}
 			}
-
-			output = append(output, computerNewSemverOutput)
+			output = append(output, result)
 		}
 
 		outputBuf := make([]ComputeNewSemverOutput, len(p.ctx.Projects))
@@ -73,11 +84,16 @@ func (p *Parser) Run(ctx context.Context, repository *git.Repository) ([]Compute
 
 		for i, project := range p.ctx.Projects {
 			g.Go(func() error {
-				result, err := p.ComputeNewSemver(repository, project, gitBranch)
-				if err != nil {
-					return fmt.Errorf("computing project %q new semver: %w", project.Name, err)
+				var result ComputeNewSemverOutput
+				if branchErr != nil {
+					result = createResultWithError(gitBranch.Name, branchErr)
+				} else {
+					var err error
+					result, err = p.ComputeNewSemver(repository, project, gitBranch, semverMap)
+					if err != nil {
+						return fmt.Errorf("computing project %q new semver: %w", project.Name, err)
+					}
 				}
-
 				outputBuf[i] = result
 				return nil
 			})
@@ -95,45 +111,64 @@ func (p *Parser) Run(ctx context.Context, repository *git.Repository) ([]Compute
 
 // ComputeNewSemver returns the next, if any, semantic version number from a given Git repository by parsing its commit
 // history.
-func (p *Parser) ComputeNewSemver(repository *git.Repository, project monorepo.Project, branch branch.Branch) (ComputeNewSemverOutput, error) {
+func (p *Parser) ComputeNewSemver(repository *git.Repository, project monorepo.Project, branch branch.Branch, semverMap map[string]*TagInfo) (ComputeNewSemverOutput, error) {
 	output := ComputeNewSemverOutput{}
 
 	if project.Name != "" {
 		output.Project = project
 	}
 
-	latestSemverTag, err := p.FetchLatestSemverTag(repository, project)
+	// fetch latest commit to only check against versions that where release before this commit
+	p.mu.Lock()
+	head, err := repository.Head()
+	if err != nil {
+		return output, fmt.Errorf("fetching head: %w", err)
+	}
+
+	lastCommit, err := repository.CommitObject(head.Hash())
+	if err != nil {
+		return output, fmt.Errorf("fetching last commit: %w", err)
+	}
+	p.mu.Unlock()
+
+	latestTagInfo, err := p.FetchLatestSemverTag(repository, project, branch, lastCommit)
 	if err != nil {
 		return output, fmt.Errorf("fetching latest semver tag: %w", err)
 	}
 
+	// check latest tag info against higher tier channel tag info, if available
+	var latestSemver *semver.Version
+	currentTagInfo := semverMap[project.Name]
+	if currentTagInfo != nil && currentTagInfo.Commit.Committer.When.Compare(lastCommit.Committer.When) < 1 &&
+		(latestTagInfo.Semver == nil || semver.Compare(currentTagInfo.Semver, latestTagInfo.Semver) == 1) {
+
+		latestTagInfo = currentTagInfo
+		latestSemver = currentTagInfo.Semver.Clone()
+	} else {
+		latestSemver = latestTagInfo.Semver
+	}
+
 	var (
-		latestSemver *semver.Version
-		history      []*object.Commit
-		logOptions   git.LogOptions
+		history    []*object.Commit
+		logOptions git.LogOptions
 	)
 
-	if latestSemverTag == nil {
+	var firstRelease bool
+
+	if latestSemver == nil {
 		p.ctx.Logger.Debug().Msg("no previous tag, creating one")
-
-		latestSemver = &semver.Version{Major: 0, Minor: 0, Patch: 0}
+		if !branch.Prerelease {
+			latestSemver = &semver.Version{Major: 0, Minor: 1, Patch: 0}
+		} else {
+			latestSemver = &semver.Version{Major: 0, Minor: 1, Patch: 0, Prerelease: &semver.Prerelease{Name: branch.Name, Build: 1}}
+		}
+		logOptions.Since = &time.Time{}
+		firstRelease = true
 	} else {
-		p.ctx.Logger.Debug().Str("tag", latestSemverTag.Name).Msg("latest semver tag found")
-
-		latestSemver, err = semver.NewFromString(latestSemverTag.Name)
-		if err != nil {
-			return output, fmt.Errorf("building semver from git tag: %w", err)
-		}
-
-		p.mu.Lock()
-		latestSemverTagCommit, err := latestSemverTag.Commit()
-		if err != nil {
-			return output, fmt.Errorf("fetching latest semver tag commit: %w", err)
-		}
-		p.mu.Unlock()
+		p.ctx.Logger.Debug().Str("tag", latestTagInfo.Name).Msg("latest semver tag found")
 
 		// Show all commits that are at least one second older than the latest one pointed by SemVer tag
-		since := latestSemverTagCommit.Committer.When.Add(time.Second)
+		since := latestTagInfo.Commit.Committer.When.Add(time.Second)
 		logOptions.Since = &since
 	}
 
@@ -151,28 +186,52 @@ func (p *Parser) ComputeNewSemver(repository *git.Repository, project monorepo.P
 		return nil
 	})
 
-	// Sort commit history from oldest to most recent
-	sort.Slice(history, func(i, j int) bool {
-		return history[i].Committer.When.Before(history[j].Committer.When)
-	})
-
 	var newRelease bool
+	var releaseType string
 	var commitHash plumbing.Hash
 
-	for _, commit := range history {
-		newReleaseFound, hash, err := p.ProcessCommit(commit, latestSemver, project)
+	for i := len(history) - 1; i >= 0; i-- {
+		commit := history[i]
+		commitReleaseFound, commitReleaseType, hash, err := p.ProcessCommit(commit, project)
 		if err != nil {
 			return output, fmt.Errorf("parsing commit history: %w", err)
 		}
 
-		if newReleaseFound {
+		if commitReleaseFound {
 			newRelease = true
 			commitHash = hash
 		}
+
+		if commitReleaseType != "" && !firstRelease {
+			if (releaseType == "") ||
+				(releaseType == "minor" && commitReleaseType == "major") ||
+				(releaseType == "patch" && (commitReleaseType == "minor" || commitReleaseType == "major")) {
+				releaseType = commitReleaseType
+			}
+		}
 	}
 
-	if branch.Prerelease {
-		latestSemver.Prerelease = branch.Name
+	if firstRelease && commitHash.IsZero() {
+		commitHash = history[0].Hash
+	}
+
+	if releaseType != "" {
+		if (branch.Prerelease && latestSemver.Prerelease == nil) ||
+			(latestSemver.Prerelease != nil && latestSemver.Prerelease.Name != branch.Name) {
+			latestSemver.Prerelease = &semver.Prerelease{Name: branch.Name}
+		}
+		switch releaseType {
+		case "major":
+			latestSemver.BumpMajor()
+		case "minor":
+			latestSemver.BumpMinor()
+		case "patch":
+			latestSemver.BumpPatch()
+		}
+	} else if firstRelease && !newRelease {
+		latestSemver.Major = 0
+		latestSemver.Minor = 0
+		latestSemver.Patch = 0
 	}
 
 	latestSemver.Metadata = p.ctx.BuildMetadataFlag
@@ -182,22 +241,30 @@ func (p *Parser) ComputeNewSemver(repository *git.Repository, project monorepo.P
 	output.CommitHash = commitHash
 	output.NewRelease = newRelease
 
+	if semverMap != nil && newRelease {
+		semverMap[project.Name] = &TagInfo{
+			Semver: latestSemver,
+			Name:   "(inherited)",
+			Commit: history[0],
+		}
+	}
+
 	return output, nil
 }
 
 // ProcessCommit parse a commit message and bump the latest semantic version accordingly.
-func (p *Parser) ProcessCommit(commit *object.Commit, latestSemver *semver.Version, project monorepo.Project) (bool, plumbing.Hash, error) {
+func (p *Parser) ProcessCommit(commit *object.Commit, project monorepo.Project) (bool, string, plumbing.Hash, error) {
 	if !conventionalCommitRegex.MatchString(commit.Message) {
-		return false, plumbing.ZeroHash, nil
+		return false, "", plumbing.ZeroHash, nil
 	}
 
 	if project.Name != "" {
 		containsProjectFiles, err := commitContainsProjectFiles(commit, project.Path)
 		if err != nil {
-			return false, plumbing.ZeroHash, fmt.Errorf("checking if commit contains project files: %w", err)
+			return false, "", plumbing.ZeroHash, fmt.Errorf("checking if commit contains project files: %w", err)
 		}
 		if !containsProjectFiles {
-			return false, plumbing.ZeroHash, nil
+			return false, "", plumbing.ZeroHash, nil
 		}
 	}
 
@@ -206,30 +273,24 @@ func (p *Parser) ProcessCommit(commit *object.Commit, latestSemver *semver.Versi
 	commitType := match[1]
 
 	if breakingChange {
-		latestSemver.BumpMajor()
-		return true, commit.Hash, nil
+		return true, "major", commit.Hash, nil
 	}
 
 	releaseType, ok := p.ctx.Rules.Map[commitType]
 	if !ok {
-		return false, plumbing.ZeroHash, nil
+		return false, "", plumbing.ZeroHash, nil
 	}
 
-	switch releaseType {
-	case "patch":
-		latestSemver.BumpPatch()
-	case "minor":
-		latestSemver.BumpMinor()
-	default:
-		return false, plumbing.ZeroHash, fmt.Errorf("unknown release type %q", releaseType)
+	if releaseType != "patch" && releaseType != "minor" {
+		return false, "", plumbing.ZeroHash, fmt.Errorf("unknown release type %q", releaseType)
 	}
 
-	return true, commit.Hash, nil
+	return true, releaseType, commit.Hash, nil
 }
 
 // FetchLatestSemverTag parses a Git repository to fetch the tag corresponding to the highest semantic version number
 // among all tags.
-func (p *Parser) FetchLatestSemverTag(repository *git.Repository, project monorepo.Project) (*object.Tag, error) {
+func (p *Parser) FetchLatestSemverTag(repository *git.Repository, project monorepo.Project, branch branch.Branch, lastCommit *object.Commit) (*TagInfo, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -238,12 +299,23 @@ func (p *Parser) FetchLatestSemverTag(repository *git.Repository, project monore
 		return nil, fmt.Errorf("fetching tag objects: %w", err)
 	}
 
-	var (
-		latestSemver *semver.Version
-		latestTag    *object.Tag
-	)
+	result := &TagInfo{}
+
+	channel := branch.Name
+	if !branch.Prerelease {
+		channel = ""
+	}
 
 	err = tags.ForEach(func(tag *object.Tag) error {
+		tagCommit, err := tag.Commit()
+		if err != nil {
+			return nil
+		}
+
+		if lastCommit != nil && tagCommit.Committer.When.After(lastCommit.Committer.When) {
+			return nil
+		}
+
 		if !semver.Regex.MatchString(tag.Name) {
 			return nil
 		}
@@ -253,21 +325,28 @@ func (p *Parser) FetchLatestSemverTag(repository *git.Repository, project monore
 		}
 
 		currentSemver, err := semver.NewFromString(tag.Name)
+
+		if currentSemver != nil && semver.CompareChannel(currentSemver, channel) == -1 {
+			return nil
+		}
+
 		if err != nil {
 			return fmt.Errorf("converting tag to semver: %w", err)
 		}
 
-		if latestSemver == nil || semver.Compare(latestSemver, currentSemver) == -1 {
-			latestSemver = currentSemver
-			latestTag = tag
+		if result.Semver == nil || semver.Compare(result.Semver, currentSemver) == -1 {
+			result.Semver = currentSemver
+			result.Name = tag.Name
+			result.Commit = tagCommit
 		}
 		return nil
 	})
+
 	if err != nil {
 		return nil, fmt.Errorf("looping over tags: %w", err)
 	}
 
-	return latestTag, nil
+	return result, nil
 }
 
 // checkoutBranch moves the HEAD pointer of the given repository to the given branch. This function expects the
@@ -305,6 +384,18 @@ func (p *Parser) checkoutBranch(repository *git.Repository, branchName string) e
 	}
 
 	return nil
+}
+
+// empty ComputeNewSemverOutput with error
+func createResultWithError(branch string, err error) ComputeNewSemverOutput {
+	return ComputeNewSemverOutput{
+		Semver:     &semver.Version{},
+		Project:    monorepo.Project{},
+		Branch:     branch,
+		CommitHash: plumbing.ZeroHash,
+		NewRelease: false,
+		Error:      err,
+	}
 }
 
 // commitContainsProjectFiles checks if a given commit changes contain at least one file whose path belongs to the

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -80,10 +80,11 @@ func TestParser_FetchLatestSemverTag_NoTag(t *testing.T) {
 
 	parser := New(th.Ctx)
 
-	latest, err := parser.FetchLatestSemverTag(testRepository.Repository, monorepo.Project{})
+	latestTagInfo, err := parser.FetchLatestSemverTag(testRepository.Repository, monorepo.Project{}, branch.Branch{}, nil)
 	checkErr(t, "fetching latest semver tag", err)
 
-	assert.Nil(latest, "latest semver tag should be nil")
+	assert.Nil(latestTagInfo.Semver, "latest semver struct should be nil")
+	assert.Nil(latestTagInfo.Semver, "latest semver tag should be nil")
 }
 
 func TestParser_FetchLatestSemverTag_OneTag(t *testing.T) {
@@ -107,10 +108,13 @@ func TestParser_FetchLatestSemverTag_OneTag(t *testing.T) {
 	th := NewTestHelper(t)
 	parser := New(th.Ctx)
 
-	latest, err := parser.FetchLatestSemverTag(testRepository.Repository, monorepo.Project{})
+	latestTagInfo, err := parser.FetchLatestSemverTag(testRepository.Repository, monorepo.Project{}, branch.Branch{}, nil)
 	checkErr(t, "fetching latest semver tag", err)
 
-	assert.Equal(tagName, latest.Name, "latest semver tagName should be equal")
+	wantSemver := &semver.Version{Major: 1, Minor: 0, Patch: 0}
+
+	assert.Equal(wantSemver, latestTagInfo.Semver, "latest semver struct should be equal")
+	assert.Equal(tagName, latestTagInfo.Name, "latest semver tagName should be equal")
 }
 
 func TestParser_FetchLatestSemverTag_MultipleTags(t *testing.T) {
@@ -128,7 +132,20 @@ func TestParser_FetchLatestSemverTag_MultipleTags(t *testing.T) {
 		t.Fatalf("fetching head: %s", err)
 	}
 
-	tags := []string{"2.0.0", "2.0.1", "3.0.0", "2.5.0", "0.0.2", "0.0.1", "0.1.0", "1.0.0"}
+	tags := []string{
+		"2.0.0",
+		"2.0.1",
+		"4.0.0-beta.2",
+		"3.0.0",
+		"2.5.0",
+		"4.0.0-beta.1",
+		"0.0.2",
+		"0.0.1",
+		"0.1.0",
+		"5.0.0-alpha.2",
+		"1.0.0",
+		"5.0.0-alpha.3",
+	}
 
 	for _, v := range tags {
 		err = testRepository.AddTag(v, head.Hash())
@@ -138,11 +155,142 @@ func TestParser_FetchLatestSemverTag_MultipleTags(t *testing.T) {
 	th := NewTestHelper(t)
 	parser := New(th.Ctx)
 
-	latest, err := parser.FetchLatestSemverTag(testRepository.Repository, monorepo.Project{})
+	// test main branch
+	latestTagInfo, err := parser.FetchLatestSemverTag(testRepository.Repository, monorepo.Project{}, branch.Branch{}, nil)
 	checkErr(t, "fetching latest semver tag", err)
 
 	want := "3.0.0"
-	assert.Equal(want, latest.Name, "latest semver tag should be equal")
+	wantSemver := &semver.Version{Major: 3, Minor: 0, Patch: 0}
+
+	assert.Equal(wantSemver, latestTagInfo.Semver, "latest semver struct should be equal")
+	assert.Equal(want, latestTagInfo.Name, "latest semver tag should be equal")
+
+	// test beta branch
+	latestTagInfo, err = parser.FetchLatestSemverTag(testRepository.Repository, monorepo.Project{}, branch.Branch{Name: "beta", Prerelease: true}, nil)
+	checkErr(t, "fetching latest semver tag", err)
+
+	want = "4.0.0-beta.2"
+	wantSemver = &semver.Version{Major: 4, Minor: 0, Patch: 0, Prerelease: &semver.Prerelease{Name: "beta", Build: 2}}
+
+	assert.Equal(wantSemver, latestTagInfo.Semver, "latest semver struct should be equal")
+	assert.Equal(want, latestTagInfo.Name, "latest semver tag should be equal")
+
+	// test alpha branch
+	latestTagInfo, err = parser.FetchLatestSemverTag(testRepository.Repository, monorepo.Project{}, branch.Branch{Name: "alpha", Prerelease: true}, nil)
+	checkErr(t, "fetching latest semver tag", err)
+
+	want = "5.0.0-alpha.3"
+	wantSemver = &semver.Version{Major: 5, Minor: 0, Patch: 0, Prerelease: &semver.Prerelease{Name: "alpha", Build: 3}}
+
+	assert.Equal(wantSemver, latestTagInfo.Semver, "latest semver struct should be equal")
+	assert.Equal(want, latestTagInfo.Name, "latest semver tag should be equal")
+}
+
+func TestParser_FetchLatestSemverTag_MultipleTags_NewPrereleaseBranch(t *testing.T) {
+	assert := assertion.New(t)
+
+	testRepository, err := gittest.NewRepository()
+	checkErr(t, "creating repository", err)
+
+	t.Cleanup(func() {
+		_ = testRepository.Remove()
+	})
+
+	head, err := testRepository.Head()
+	if err != nil {
+		t.Fatalf("fetching head: %s", err)
+	}
+
+	tags := []string{
+		"2.0.0",
+		"2.0.1",
+		"3.0.0",
+		"2.5.0",
+		"0.0.2",
+		"0.0.1",
+		"0.1.0",
+		"1.0.0",
+	}
+
+	for _, v := range tags {
+		err = testRepository.AddTag(v, head.Hash())
+		checkErr(t, "creating tag", err)
+	}
+
+	th := NewTestHelper(t)
+	parser := New(th.Ctx)
+
+	// test beta branch
+	latestTagInfo, err := parser.FetchLatestSemverTag(testRepository.Repository, monorepo.Project{}, branch.Branch{Name: "beta", Prerelease: true}, nil)
+	checkErr(t, "fetching latest semver tag", err)
+
+	want := "3.0.0"
+	wantSemver := &semver.Version{Major: 3, Minor: 0, Patch: 0}
+
+	assert.Equal(wantSemver, latestTagInfo.Semver, "latest semver struct should be equal")
+	assert.Equal(want, latestTagInfo.Name, "latest semver tag should be equal")
+
+	// test new beta branch
+	latestTagInfo, err = parser.FetchLatestSemverTag(testRepository.Repository, monorepo.Project{}, branch.Branch{Name: "beta", Prerelease: true}, nil)
+	checkErr(t, "fetching latest semver tag", err)
+
+	want = "3.0.0"
+	wantSemver = &semver.Version{Major: 3, Minor: 0, Patch: 0}
+
+	assert.Equal(wantSemver, latestTagInfo.Semver, "latest semver struct should be equal")
+	assert.Equal(want, latestTagInfo.Name, "latest semver tag should be equal")
+
+	// test beta branch with releases
+	tags = []string{
+		"4.0.0-beta.5",
+		"4.0.0-beta.1",
+		"4.0.0-beta.3",
+	}
+
+	for _, v := range tags {
+		err = testRepository.AddTag(v, head.Hash())
+		checkErr(t, "creating tag", err)
+	}
+
+	latestTagInfo, err = parser.FetchLatestSemverTag(testRepository.Repository, monorepo.Project{}, branch.Branch{Name: "beta", Prerelease: true}, nil)
+	checkErr(t, "fetching latest semver tag", err)
+
+	want = "4.0.0-beta.5"
+	wantSemver = &semver.Version{Major: 4, Minor: 0, Patch: 0, Prerelease: &semver.Prerelease{Name: "beta", Build: 5}}
+
+	assert.Equal(wantSemver, latestTagInfo.Semver, "latest semver struct should be equal")
+	assert.Equal(want, latestTagInfo.Name, "latest semver tag should be equal")
+
+	// test new alpha branch
+	latestTagInfo, err = parser.FetchLatestSemverTag(testRepository.Repository, monorepo.Project{}, branch.Branch{Name: "alpha", Prerelease: true}, nil)
+	checkErr(t, "fetching latest semver tag", err)
+
+	want = "4.0.0-beta.5"
+	wantSemver = &semver.Version{Major: 4, Minor: 0, Patch: 0, Prerelease: &semver.Prerelease{Name: "beta", Build: 5}}
+
+	assert.Equal(wantSemver, latestTagInfo.Semver, "latest semver struct should be equal")
+	assert.Equal(want, latestTagInfo.Name, "latest semver tag should be equal")
+
+	// test alpha branch with releases
+	tags = []string{
+		"5.0.0-alpha.5",
+		"5.0.0-alpha.1",
+		"5.0.0-alpha.3",
+	}
+
+	for _, v := range tags {
+		err = testRepository.AddTag(v, head.Hash())
+		checkErr(t, "creating tag", err)
+	}
+
+	latestTagInfo, err = parser.FetchLatestSemverTag(testRepository.Repository, monorepo.Project{}, branch.Branch{Name: "alpha", Prerelease: true}, nil)
+	checkErr(t, "fetching latest semver tag", err)
+
+	want = "5.0.0-alpha.5"
+	wantSemver = &semver.Version{Major: 5, Minor: 0, Patch: 0, Prerelease: &semver.Prerelease{Name: "alpha", Build: 5}}
+
+	assert.Equal(wantSemver, latestTagInfo.Semver, "latest semver struct should be equal")
+	assert.Equal(want, latestTagInfo.Name, "latest semver tag should be equal")
 }
 
 func TestParser_ComputeNewSemver_UntaggedRepository_NoRelease(t *testing.T) {
@@ -158,7 +306,7 @@ func TestParser_ComputeNewSemver_UntaggedRepository_NoRelease(t *testing.T) {
 	th := NewTestHelper(t)
 	parser := New(th.Ctx)
 
-	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0])
+	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0], nil)
 	checkErr(t, "computing new semver", err)
 
 	want := "0.0.0"
@@ -182,10 +330,10 @@ func TestParser_ComputeNewSemver_UntaggedRepository_PatchRelease(t *testing.T) {
 	th := NewTestHelper(t)
 	parser := New(th.Ctx)
 
-	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0])
+	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0], nil)
 	checkErr(t, "computing new semver", err)
 
-	want := "0.0.1"
+	want := "0.1.0"
 	assert.Equal(want, output.Semver.String(), "version should be equal")
 }
 
@@ -213,7 +361,7 @@ func TestParser_ComputeNewSemver_UnknownReleaseType(t *testing.T) {
 	th.Ctx.Rules = invalidRules
 	parser := New(th.Ctx)
 
-	_, err = parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0])
+	_, err = parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0], nil)
 	assert.ErrorContains(err, "unknown release type")
 }
 
@@ -233,7 +381,7 @@ func TestParser_ComputeNewSemver_UntaggedRepository_MinorRelease(t *testing.T) {
 	th := NewTestHelper(t)
 	parser := New(th.Ctx)
 
-	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0])
+	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0], nil)
 	checkErr(t, "computing new semver", err)
 
 	want := "0.1.0"
@@ -250,22 +398,78 @@ func TestParser_ComputeNewSemver_UntaggedRepository_MajorRelease(t *testing.T) {
 		_ = testRepository.Remove()
 	})
 
-	_, err = testRepository.AddCommit("feat!")
+	_, err = testRepository.AddCommit("feat!") // 0.1.0
 	checkErr(t, "adding commit", err)
 
 	th := NewTestHelper(t)
 	parser := New(th.Ctx)
 
-	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0])
+	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0], nil)
 	checkErr(t, "computing new semver ", err)
 
-	want := "1.0.0"
+	want := "0.1.0"
 
 	assert.Equal(want, output.Semver.String(), "version should be equal")
 	assert.Equal(true, output.NewRelease, "boolean should be equal")
 }
 
-func TestParser_ComputeNewSemver_TaggedRepository(t *testing.T) {
+func TestParser_ComputeNewSemver_UntaggedRepository_Prerelease(t *testing.T) {
+	assert := assertion.New(t)
+
+	testRepository, err := gittest.NewRepository()
+	checkErr(t, "creating repository", err)
+
+	t.Cleanup(func() {
+		_ = testRepository.Remove()
+	})
+
+	_, err = testRepository.AddCommit("feat!") // 0.1.0-beata.1
+	checkErr(t, "adding commit", err)
+
+	th := NewTestHelper(t)
+	parser := New(th.Ctx)
+
+	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[1], nil)
+	checkErr(t, "computing new semver ", err)
+
+	want := "0.1.0-beta.1"
+
+	assert.Equal(want, output.Semver.String(), "version should be equal")
+	assert.Equal(true, output.NewRelease, "boolean should be equal")
+}
+
+func TestParser_ComputeNewSemver_TaggedRepository_PatchRelease(t *testing.T) {
+	assert := assertion.New(t)
+
+	testRepository, err := gittest.NewRepository()
+	checkErr(t, "creating repository", err)
+
+	t.Cleanup(func() {
+		_ = testRepository.Remove()
+	})
+
+	firstCommitHash, err := testRepository.AddCommit("feat!") // 1.0.0
+	checkErr(t, "adding commit", err)
+
+	err = testRepository.AddTag("1.0.0", firstCommitHash)
+	checkErr(t, "adding tag", err)
+
+	_, err = testRepository.AddCommit("fix") // 1.0.1
+	checkErr(t, "adding commit", err)
+
+	th := NewTestHelper(t)
+	parser := New(th.Ctx)
+
+	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0], nil)
+	checkErr(t, "computing new semver ", err)
+
+	want := "1.0.1"
+
+	assert.Equal(want, output.Semver.String(), "version should be equal")
+	assert.Equal(true, output.NewRelease, "boolean should be equal")
+}
+
+func TestParser_ComputeNewSemver_TaggedRepository_PatchRelease_MinorRelease(t *testing.T) {
 	assert := assertion.New(t)
 
 	testRepository, err := gittest.NewRepository()
@@ -283,16 +487,82 @@ func TestParser_ComputeNewSemver_TaggedRepository(t *testing.T) {
 
 	_, err = testRepository.AddCommit("feat") // 1.1.0
 	checkErr(t, "adding commit", err)
-	_, err = testRepository.AddCommit("fix") // 1.1.1
+	_, err = testRepository.AddCommit("fix") // 1.1.0
 	checkErr(t, "adding commit", err)
 
 	th := NewTestHelper(t)
 	parser := New(th.Ctx)
 
-	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0])
+	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0], nil)
 	checkErr(t, "computing new semver ", err)
 
-	want := "1.1.1"
+	want := "1.1.0"
+
+	assert.Equal(want, output.Semver.String(), "version should be equal")
+	assert.Equal(true, output.NewRelease, "boolean should be equal")
+}
+
+func TestParser_ComputeNewSemver_TaggedRepository_PatchRelease_MajorRelease(t *testing.T) {
+	assert := assertion.New(t)
+
+	testRepository, err := gittest.NewRepository()
+	checkErr(t, "creating repository", err)
+
+	t.Cleanup(func() {
+		_ = testRepository.Remove()
+	})
+
+	firstCommitHash, err := testRepository.AddCommit("feat!") // 1.0.0
+	checkErr(t, "adding commit", err)
+
+	err = testRepository.AddTag("1.0.0", firstCommitHash)
+	checkErr(t, "adding tag", err)
+
+	_, err = testRepository.AddCommit("feat!") // 2.0.0
+	checkErr(t, "adding commit", err)
+	_, err = testRepository.AddCommit("fix") // 2.0.0
+	checkErr(t, "adding commit", err)
+
+	th := NewTestHelper(t)
+	parser := New(th.Ctx)
+
+	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0], nil)
+	checkErr(t, "computing new semver ", err)
+
+	want := "2.0.0"
+
+	assert.Equal(want, output.Semver.String(), "version should be equal")
+	assert.Equal(true, output.NewRelease, "boolean should be equal")
+}
+
+func TestParser_ComputeNewSemver_TaggedRepository_PatchRelease_Prerelease(t *testing.T) {
+	assert := assertion.New(t)
+
+	testRepository, err := gittest.NewRepository()
+	checkErr(t, "creating repository", err)
+
+	t.Cleanup(func() {
+		_ = testRepository.Remove()
+	})
+
+	firstCommitHash, err := testRepository.AddCommit("feat!") // 1.0.0-beta.1
+	checkErr(t, "adding commit", err)
+
+	err = testRepository.AddTag("1.0.0", firstCommitHash)
+	checkErr(t, "adding tag", err)
+
+	_, err = testRepository.AddCommit("feat!") // 2.0.0-beta.1
+	checkErr(t, "adding commit", err)
+	_, err = testRepository.AddCommit("fix") // 2.0.0-beta.1
+	checkErr(t, "adding commit", err)
+
+	th := NewTestHelper(t)
+	parser := New(th.Ctx)
+
+	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[1], nil)
+	checkErr(t, "computing new semver ", err)
+
+	want := "2.0.0-beta.1"
 
 	assert.Equal(want, output.Semver.String(), "version should be equal")
 	assert.Equal(true, output.NewRelease, "boolean should be equal")
@@ -314,7 +584,7 @@ func TestParser_ComputeNewSemver_UninitializedRepository(t *testing.T) {
 	th := NewTestHelper(t)
 	parser := New(th.Ctx)
 
-	_, err = parser.ComputeNewSemver(repository, monorepo.Project{}, th.Ctx.Branches[0])
+	_, err = parser.ComputeNewSemver(repository, monorepo.Project{}, th.Ctx.Branches[0], nil)
 	assert.ErrorIs(err, plumbing.ErrReferenceNotFound)
 }
 
@@ -335,7 +605,7 @@ func TestParser_ComputeNewSemver_BuildMetadata(t *testing.T) {
 	th.Ctx.BuildMetadataFlag = "metadata"
 	parser := New(th.Ctx)
 
-	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0])
+	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0], nil)
 	checkErr(t, "computing new semver", err)
 
 	want := semver.Version{
@@ -362,20 +632,17 @@ func TestParser_ComputeNewSemver_Prerelease(t *testing.T) {
 	_, err = testRepository.AddCommit("feat")
 	checkErr(t, "adding commit", err)
 
-	prereleaseID := "master"
-
 	th := NewTestHelper(t)
-	th.Ctx.Branches[0].Prerelease = true
 	parser := New(th.Ctx)
 
-	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[0])
+	output, err := parser.ComputeNewSemver(testRepository.Repository, monorepo.Project{}, th.Ctx.Branches[1], nil)
 	checkErr(t, "computing new semver", err)
 
 	want := semver.Version{
 		Major:      0,
 		Minor:      1,
 		Patch:      0,
-		Prerelease: prereleaseID,
+		Prerelease: &semver.Prerelease{Name: th.Ctx.Branches[1].Name, Build: 1},
 	}
 
 	assert.Equal(want.String(), output.Semver.String(), "version should be equal")
@@ -383,8 +650,11 @@ func TestParser_ComputeNewSemver_Prerelease(t *testing.T) {
 }
 
 // FIXME: the "origin" name is not set when calling parser.checkoutBranch leaving remoteRef like "ref/remote/<empty>/<branch>
-func TestParser_Run_NoMonorepoOutputLength(t *testing.T) {
+func TestParser_Run_NoMonorepo(t *testing.T) {
 	assert := assertion.New(t)
+
+	th := NewTestHelper(t)
+	parser := New(th.Ctx)
 
 	testRepository, err := gittest.NewRepository()
 	checkErr(t, "creating repository", err)
@@ -393,26 +663,138 @@ func TestParser_Run_NoMonorepoOutputLength(t *testing.T) {
 		_ = testRepository.Remove()
 	})
 
+	th.CreateAllBranches(t, testRepository)
+
+	// only main channel has a release
 	_, err = testRepository.AddCommit("feat")
 	checkErr(t, "adding commit", err)
 
 	clonedTestRepository, err := testRepository.Clone()
 	checkErr(t, "cloning test repository", err)
 
+	output, err := parser.Run(context.Background(), clonedTestRepository.Repository)
+	checkErr(t, "computing new semver", err)
+
+	assert.Len(output, 3, "parser run output should contain two element")
+
+	assert.Equal("0.1.0", output[0].Semver.String(), "version should be equal")
+	assert.True(output[0].NewRelease, "should be a new release")
+	assert.Equal("0.0.0-beta.1", output[1].Semver.String(), "version should be equal")
+	assert.False(output[1].NewRelease, "should be no new release")
+	assert.Equal("0.0.0-alpha.1", output[2].Semver.String(), "version should be equal")
+	assert.False(output[2].NewRelease, "should be no new release")
+
+	// main and alpha has a release
+	_, err = testRepository.AddCommitToBranch("feat", "alpha")
+	checkErr(t, "adding commit", err)
+
+	clonedTestRepository, err = testRepository.Clone()
+	checkErr(t, "cloning test repository", err)
+
+	output, err = parser.Run(context.Background(), clonedTestRepository.Repository)
+	checkErr(t, "computing new semver", err)
+
+	assert.Equal("0.1.0", output[0].Semver.String(), "version should be equal")
+	assert.True(output[0].NewRelease, "should be a new release")
+	assert.Equal("0.0.0-beta.1", output[1].Semver.String(), "version should be equal")
+	assert.False(output[1].NewRelease, "should be no new release")
+	assert.Equal("0.2.0-alpha.1", output[2].Semver.String(), "version should be equal")
+	assert.True(output[2].NewRelease, "should be a new release")
+
+	// main, beta and alpha have a release
+	_, err = testRepository.AddCommitToBranch("feat!", "beta")
+	checkErr(t, "adding commit", err)
+	_, err = testRepository.AddCommitToBranch("fix", "alpha")
+	checkErr(t, "adding commit", err)
+
+	clonedTestRepository, err = testRepository.Clone()
+	checkErr(t, "cloning test repository", err)
+
+	output, err = parser.Run(context.Background(), clonedTestRepository.Repository)
+	checkErr(t, "computing new semver", err)
+
+	assert.Equal("0.1.0", output[0].Semver.String(), "version should be equal")
+	assert.True(output[0].NewRelease, "should be a new release")
+	assert.Equal("1.0.0-beta.1", output[1].Semver.String(), "version should be equal")
+	assert.True(output[1].NewRelease, "should be a new release")
+	assert.Equal("1.0.1-alpha.1", output[2].Semver.String(), "version should be equal")
+	assert.True(output[2].NewRelease, "should be a new release")
+}
+
+func TestParser_Run_NoMonorepoWithPreexistingTags(t *testing.T) {
+	assert := assertion.New(t)
+
 	th := NewTestHelper(t)
 	parser := New(th.Ctx)
+
+	testRepository, err := gittest.NewRepository()
+	checkErr(t, "creating repository", err)
+
+	t.Cleanup(func() {
+		_ = testRepository.Remove()
+	})
+
+	th.CreateAllBranches(t, testRepository)
+
+	// main has a release tag
+	err = testRepository.AddTagToBranch("0.1.2", "main")
+	checkErr(t, "adding foo tag", err)
+
+	_, err = testRepository.AddCommitToBranch("feat", "main")
+	checkErr(t, "adding commit", err)
+
+	clonedTestRepository, err := testRepository.Clone()
+	checkErr(t, "cloning test repository", err)
 
 	output, err := parser.Run(context.Background(), clonedTestRepository.Repository)
 	checkErr(t, "computing new semver", err)
 
-	want := semver.Version{
-		Major: 0,
-		Minor: 1,
-		Patch: 0,
-	}
+	assert.Equal("0.2.0", output[0].Semver.String(), "version should be equal")
+	assert.True(output[0].NewRelease, "should be a new release")
+	assert.Equal("0.1.2", output[1].Semver.String(), "version should be equal")
+	assert.False(output[1].NewRelease, "should be no new release")
+	assert.Equal("0.1.2", output[2].Semver.String(), "version should be equal")
+	assert.False(output[2].NewRelease, "should be no new release")
 
-	assert.Len(output, 1, "parser run output should contain one element")
-	assert.Equal(want.String(), output[0].Semver.String(), "version should be equal")
+	// main and alpha have a release tag
+	err = testRepository.AddTagToBranch("0.3.0-alpha.5", "alpha")
+	checkErr(t, "adding foo tag", err)
+
+	_, err = testRepository.AddCommitToBranch("fix", "alpha")
+	checkErr(t, "adding commit", err)
+
+	clonedTestRepository, err = testRepository.Clone()
+	checkErr(t, "cloning test repository", err)
+
+	output, err = parser.Run(context.Background(), clonedTestRepository.Repository)
+	checkErr(t, "computing new semver", err)
+
+	assert.Equal("0.2.0", output[0].Semver.String(), "version should be equal")
+	assert.True(output[0].NewRelease, "should be a new release")
+	assert.Equal("0.1.2", output[1].Semver.String(), "version should be equal")
+	assert.False(output[1].NewRelease, "should be no new release")
+	assert.Equal("0.3.0-alpha.6", output[2].Semver.String(), "version should be equal")
+	assert.True(output[2].NewRelease, "should be a new release")
+
+	// main, beta and alpha have a release tag
+	err = testRepository.AddTagToBranch("0.4.0-beta.2", "beta")
+	checkErr(t, "adding foo tag", err)
+
+	_, err = testRepository.AddCommitToBranch("feat!", "beta")
+	checkErr(t, "adding commit", err)
+
+	clonedTestRepository, err = testRepository.Clone()
+	checkErr(t, "cloning test repository", err)
+
+	output, err = parser.Run(context.Background(), clonedTestRepository.Repository)
+	checkErr(t, "computing new semver", err)
+
+	assert.Equal("0.2.0", output[0].Semver.String(), "version should be equal")
+	assert.True(output[0].NewRelease, "should be a new release")
+	assert.Equal("1.0.0-beta.1", output[1].Semver.String(), "version should be equal")
+	assert.True(output[1].NewRelease, "should be a new release")
+	assert.Equal("0.4.1-alpha.1", output[2].Semver.String(), "version should be equal")
+	assert.True(output[2].NewRelease, "should be a new release")
 }
 
 func TestParser_ShortMessage(t *testing.T) {
@@ -451,10 +833,13 @@ func TestMonorepoParser_FetchLatestSemverTagPerProjects(t *testing.T) {
 	}
 	parser := New(th.Ctx)
 
-	gotTag, err := parser.FetchLatestSemverTag(testRepository.Repository, th.Ctx.Projects[0])
+	latestTagInfo, err := parser.FetchLatestSemverTag(testRepository.Repository, th.Ctx.Projects[0], branch.Branch{}, nil)
 	checkErr(t, "fetching latest semver tag", err)
 
-	assert.Equal(gotTag.Name, wantTag, "should have found tag")
+	wantSemver := &semver.Version{Major: 1, Minor: 0, Patch: 0}
+
+	assert.Equal(wantSemver, latestTagInfo.Semver, "latest semver struct should be equal")
+	assert.Equal(wantTag, latestTagInfo.Name, "should have found tag")
 }
 
 func TestMonorepoParser_CommitContainsProjectFiles_True(t *testing.T) {
@@ -504,6 +889,13 @@ func TestMonorepoParser_CommitContainsProjectFiles_False(t *testing.T) {
 func TestParser_Run_Monorepo(t *testing.T) {
 	assert := assertion.New(t)
 
+	th := NewTestHelper(t)
+	th.Ctx.Projects = []monorepo.Project{
+		{Name: "foo", Path: "foo"},
+		{Name: "bar", Path: "bar"},
+	}
+	parser := New(th.Ctx)
+
 	testRepository, err := gittest.NewRepository()
 	checkErr(t, "creating repository", err)
 
@@ -517,6 +909,16 @@ func TestParser_Run_Monorepo(t *testing.T) {
 	_, err = testRepository.AddCommitWithSpecificFile("fix", "./foo/xyz/foo.txt")
 	checkErr(t, "adding commit", err)
 
+	// Adding unrelated commits
+	_, err = testRepository.AddCommitWithSpecificFile("fix", "./unknown/a.txt")
+	checkErr(t, "adding commit", err)
+	_, err = testRepository.AddCommitWithSpecificFile("fix", "./temp/abc/b.txt")
+	checkErr(t, "adding commit", err)
+
+	// branch beta from main
+	err = testRepository.CheckoutBranch("beta", true)
+	checkErr(t, "checkout beta branch", err)
+
 	// Adding "bar" project commits
 	_, err = testRepository.AddCommitWithSpecificFile("feat", "./bar/foo.txt")
 	checkErr(t, "adding commit", err)
@@ -525,18 +927,13 @@ func TestParser_Run_Monorepo(t *testing.T) {
 	_, err = testRepository.AddCommitWithSpecificFile("fix", "./bar/baz/xyz/bar.txt")
 	checkErr(t, "adding commit", err)
 
-	// Adding unrelated commits
-	_, err = testRepository.AddCommitWithSpecificFile("fix", "./unknown/a.txt")
-	checkErr(t, "adding commit", err)
-	_, err = testRepository.AddCommitWithSpecificFile("fix", "./temp/abc/b.txt")
-	checkErr(t, "adding commit", err)
+	// branch alpha from beta
+	err = testRepository.CheckoutBranch("alpha", true)
+	checkErr(t, "checkout alpha branch", err)
 
-	th := NewTestHelper(t)
-	th.Ctx.Projects = []monorepo.Project{
-		{Name: "foo", Path: "foo"},
-		{Name: "bar", Path: "bar"},
-	}
-	parser := New(th.Ctx)
+	// Adding "foo" project commits
+	_, err = testRepository.AddCommitWithSpecificFile("feat!", "./foo/foo.txt")
+	checkErr(t, "adding commit", err)
 
 	clonedTestRepository, err := testRepository.Clone()
 	checkErr(t, "cloning test repository", err)
@@ -544,16 +941,37 @@ func TestParser_Run_Monorepo(t *testing.T) {
 	output, err := parser.Run(context.Background(), clonedTestRepository.Repository)
 	checkErr(t, "computing projects new semver", err)
 
-	assert.Len(output, 2, "parser run output should contain two elements")
+	assert.Len(output, 6, "parser run output should contain four elements")
 
-	gotSemver := []string{output[0].Semver.String(), output[1].Semver.String()}
-
-	assert.Contains(gotSemver, "1.0.1")
-	assert.Contains(gotSemver, "0.1.2")
+	// main foo
+	assert.Equal("0.1.0", output[0].Semver.String())
+	assert.True(output[0].NewRelease, "should be a new release")
+	// main bar
+	assert.Equal("0.0.0", output[1].Semver.String())
+	assert.False(output[1].NewRelease, "should be no new release")
+	// beta foo
+	assert.Equal("0.1.0", output[2].Semver.String())
+	assert.False(output[2].NewRelease, "should be no new release")
+	// beta bar
+	assert.Equal("0.1.0-beta.1", output[3].Semver.String())
+	assert.True(output[3].NewRelease, "should be a new release")
+	// alpha foo
+	assert.Equal("1.0.0-alpha.1", output[4].Semver.String())
+	assert.True(output[4].NewRelease, "should be a new release")
+	// alpha bar
+	assert.Equal("0.1.0-beta.1", output[5].Semver.String())
+	assert.False(output[5].NewRelease, "should be no new release")
 }
 
 func TestParser_Run_MonorepoWithPreexistingTags(t *testing.T) {
 	assert := assertion.New(t)
+
+	th := NewTestHelper(t)
+	th.Ctx.Projects = []monorepo.Project{
+		{Name: "foo", Path: "foo"},
+		{Name: "bar", Path: "bar"},
+	}
+	parser := New(th.Ctx)
 
 	testRepository, err := gittest.NewRepository()
 	checkErr(t, "creating repository", err)
@@ -570,24 +988,24 @@ func TestParser_Run_MonorepoWithPreexistingTags(t *testing.T) {
 	checkErr(t, "adding foo tag", err)
 
 	// Add previous "bar" tags
-	barCommit, err := testRepository.AddCommitWithSpecificFile("chore!", "./bar/foo.txt")
+	barCommit, err := testRepository.AddCommitWithSpecificFile("chore!", "./bar/foo.txt") // bar-1.0.0
 	checkErr(t, "adding commit", err)
 
-	err = testRepository.AddTag("bar-1.0.0", barCommit) // bar-1.0.0
+	err = testRepository.AddTag("bar-1.0.0", barCommit)
 	checkErr(t, "adding bar tag", err)
 
 	// Adding "foo" project commits
 	_, err = testRepository.AddCommitWithSpecificFile("feat!", "./foo/foo.txt") // foo-2.0.0
 	checkErr(t, "adding commit", err)
-	_, err = testRepository.AddCommitWithSpecificFile("fix", "./foo/xyz/foo.txt") // foo-2.0.1
+	_, err = testRepository.AddCommitWithSpecificFile("fix", "./foo/xyz/foo.txt") // foo-2.0.0
 	checkErr(t, "adding commit", err)
 
 	// Adding "bar" project commits
 	_, err = testRepository.AddCommitWithSpecificFile("feat", "./bar/foo.txt") // bar-1.1.0
 	checkErr(t, "adding commit", err)
-	_, err = testRepository.AddCommitWithSpecificFile("fix", "./bar/baz/xyz/foo.txt") // bar-1.1.1
+	_, err = testRepository.AddCommitWithSpecificFile("fix", "./bar/baz/xyz/foo.txt") // bar-1.1.0
 	checkErr(t, "adding commit", err)
-	_, err = testRepository.AddCommitWithSpecificFile("fix", "./bar/baz/xyz/bar.txt") // bar-1.1.2
+	_, err = testRepository.AddCommitWithSpecificFile("fix", "./bar/baz/xyz/bar.txt") // bar-1.1.0
 	checkErr(t, "adding commit", err)
 
 	// Adding unrelated commits
@@ -596,12 +1014,33 @@ func TestParser_Run_MonorepoWithPreexistingTags(t *testing.T) {
 	_, err = testRepository.AddCommitWithSpecificFile("fix", "./temp/abc/b.txt")
 	checkErr(t, "adding commit", err)
 
-	th := NewTestHelper(t)
-	th.Ctx.Projects = []monorepo.Project{
-		{Name: "foo", Path: "foo"},
-		{Name: "bar", Path: "bar"},
-	}
-	parser := New(th.Ctx)
+	// branch beta from main
+	err = testRepository.CheckoutBranch("beta", true)
+	checkErr(t, "checkout beta branch", err)
+
+	// Adding "foo" project beta commits
+	fooCommit, err = testRepository.AddCommitWithSpecificFile("feat", "./foo/foo.txt") // foo-2.1.0-beta.1
+	checkErr(t, "adding commit", err)
+	err = testRepository.AddTag("foo-2.1.0-beta.1", fooCommit)
+	checkErr(t, "adding foo tag", err)
+	_, err = testRepository.AddCommitWithSpecificFile("fix", "./foo/xyz/foo.txt") // foo-2.1.0-beta.2
+	checkErr(t, "adding commit", err)
+
+	// Adding "bar" beta commits
+	barCommit, err = testRepository.AddCommitWithSpecificFile("feat!", "./bar/foo.txt") // bar-2.0.0-beta.1
+	checkErr(t, "adding commit", err)
+	err = testRepository.AddTag("bar-2.0.0-beta.1", barCommit)
+	checkErr(t, "adding foo tag", err)
+	_, err = testRepository.AddCommitWithSpecificFile("fix", "./bar/baz/xyz/foo.txt") // bar-2.0.0-beta.2
+	checkErr(t, "adding commit", err)
+
+	// branch alpha from beta
+	err = testRepository.CheckoutBranch("alpha", true)
+	checkErr(t, "checkout alpha branch", err)
+
+	// Adding "bar" alpha commits
+	_, err = testRepository.AddCommitWithSpecificFile("feat!", "./bar/foo.txt") // bar-3.0.0-beta.1
+	checkErr(t, "adding commit", err)
 
 	clonedTestRepository, err := testRepository.Clone()
 	checkErr(t, "cloning test repository", err)
@@ -609,12 +1048,26 @@ func TestParser_Run_MonorepoWithPreexistingTags(t *testing.T) {
 	output, err := parser.Run(context.Background(), clonedTestRepository.Repository)
 	checkErr(t, "computing projects new semver", err)
 
-	assert.Len(output, 2, "parser run output should contain two elements")
+	assert.Len(output, 6, "parser run output should contain four elements")
 
-	gotSemver := []string{output[0].Semver.String(), output[1].Semver.String()}
-
-	assert.Contains(gotSemver, "2.0.1")
-	assert.Contains(gotSemver, "1.1.2")
+	// main foo
+	assert.Equal("2.0.0", output[0].Semver.String())
+	assert.True(output[0].NewRelease, "should be a new release")
+	// main bar
+	assert.Equal("1.1.0", output[1].Semver.String())
+	assert.True(output[1].NewRelease, "should be a new release")
+	// beta foo
+	assert.Equal("2.1.0-beta.2", output[2].Semver.String())
+	assert.True(output[2].NewRelease, "should be a new release")
+	// beta bar
+	assert.Equal("2.0.0-beta.2", output[3].Semver.String())
+	assert.True(output[3].NewRelease, "should be a new release")
+	// alpha foo
+	assert.Equal("2.1.0-beta.2", output[4].Semver.String())
+	assert.False(output[4].NewRelease, "should be no new release")
+	// alpha bar
+	assert.Equal("3.0.0-alpha.1", output[5].Semver.String())
+	assert.True(output[5].NewRelease, "should be a new release")
 }
 
 func TestParser_Run_InvalidBranch(t *testing.T) {
@@ -632,8 +1085,10 @@ func TestParser_Run_InvalidBranch(t *testing.T) {
 
 	parser := New(th.Ctx)
 
-	_, err = parser.Run(context.Background(), testRepository.Repository)
-	assert.ErrorIs(err, plumbing.ErrReferenceNotFound, "parser run should have failed since branch does not exist")
+	output, err := parser.Run(context.Background(), testRepository.Repository)
+	checkErr(t, "running parser", err)
+	assert.ErrorIs(output[0].Error, plumbing.ErrReferenceNotFound, "output should contain corresponding checkout error since branch does not exist")
+
 }
 
 func checkErr(t *testing.T, msg string, err error) {
@@ -677,11 +1132,27 @@ func NewTestHelper(t *testing.T) *TestHelper {
 	ctx := &appcontext.AppContext{
 		Rules:          rule.Default,
 		RemoteNameFlag: "origin",
-		Branches:       []branch.Branch{{Name: "master"}},
-		Logger:         zerolog.New(io.Discard),
+		Branches: []branch.Branch{
+			{Name: "main"},
+			{Name: "beta", Prerelease: true},
+			{Name: "alpha", Prerelease: true},
+		},
+		Logger: zerolog.New(io.Discard),
 	}
 
 	return &TestHelper{
 		Ctx: ctx,
 	}
+}
+
+func (th *TestHelper) CreateAllBranches(t *testing.T, r *gittest.TestRepository) {
+	for _, branch := range th.Ctx.Branches {
+		if branch.Name == "main" {
+			continue
+		}
+		err := r.CheckoutBranch(branch.Name, true)
+		checkErr(t, fmt.Sprintf("adding %s branch", branch.Name), err)
+	}
+	err := r.CheckoutBranch("main", false)
+	checkErr(t, "checkout main branch", err)
 }

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -10,33 +10,68 @@ import (
 
 var Regex = regexp.MustCompile(`(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 
+type Prerelease struct {
+	Name  string
+	Build int
+}
+
 type Version struct {
 	Major      int
 	Minor      int
 	Patch      int
-	Prerelease string
+	Prerelease *Prerelease
 	Metadata   string
 }
 
 func (v *Version) BumpMajor() {
-	v.Major++
+	if v.Prerelease != nil && v.Minor == 0 && v.Patch == 0 && v.Prerelease.Build != 0 {
+		v.Prerelease.Build++
+	} else {
+		v.Major++
+		if v.Prerelease != nil {
+			v.Prerelease.Build = 1
+		}
+	}
 	v.Minor = 0
 	v.Patch = 0
-	v.Prerelease = ""
 	v.Metadata = ""
 }
 
 func (v *Version) BumpMinor() {
-	v.Minor++
+	if v.Prerelease != nil && v.Patch == 0 && v.Prerelease.Build != 0 {
+		v.Prerelease.Build++
+	} else {
+		v.Minor++
+		if v.Prerelease != nil {
+			v.Prerelease.Build = 1
+		}
+	}
 	v.Patch = 0
-	v.Prerelease = ""
 	v.Metadata = ""
 }
 
 func (v *Version) BumpPatch() {
-	v.Patch++
-	v.Prerelease = ""
+	if v.Prerelease != nil && v.Prerelease.Build != 0 {
+		v.Prerelease.Build++
+	} else {
+		v.Patch++
+		if v.Prerelease != nil {
+			v.Prerelease.Build = 1
+		}
+	}
 	v.Metadata = ""
+}
+
+// clones the given semver struct
+func (v *Version) Clone() *Version {
+	if v == nil {
+		return nil
+	}
+	result := &Version{Major: v.Major, Minor: v.Minor, Patch: v.Patch, Metadata: v.Metadata}
+	if v.Prerelease != nil {
+		result.Prerelease = &Prerelease{Name: v.Prerelease.Name, Build: v.Prerelease.Build}
+	}
+	return result
 }
 
 // IsZero checks if all component of a semantic version number are equal to zero.
@@ -48,8 +83,8 @@ func (v *Version) IsZero() bool {
 func (v *Version) String() string {
 	str := fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
 
-	if v.Prerelease != "" {
-		str += "-" + v.Prerelease
+	if v.Prerelease != nil && v.Prerelease.Name != "" {
+		str += "-" + v.Prerelease.String()
 	}
 
 	if v.Metadata != "" {
@@ -57,6 +92,10 @@ func (v *Version) String() string {
 	}
 
 	return str
+}
+
+func (p *Prerelease) String() string {
+	return fmt.Sprintf("%s.%d", p.Name, p.Build)
 }
 
 // NewFromString returns a semver struct corresponding to the string used as an input.
@@ -80,12 +119,40 @@ func NewFromString(str string) (*Version, error) {
 		return nil, fmt.Errorf("converting patch component: %w", err)
 	}
 
-	prerelease := submatch[4]
+	prerelease, err := PrereleaseFromString(submatch[4])
+	if err != nil {
+		return nil, err
+	}
 	buildMetadata := submatch[5]
 
 	semver := &Version{Major: major, Minor: minor, Patch: patch, Prerelease: prerelease, Metadata: buildMetadata}
 
 	return semver, nil
+}
+
+// PrereleaseFromString returns a semver conform prerelease struct.
+func PrereleaseFromString(str string) (*Prerelease, error) {
+	var name, build = "", 0
+	parts := strings.Split(str, ".")
+	length := len(parts)
+	if length == 0 {
+		return nil, fmt.Errorf("Prerelease `%s` has the wrong format", str)
+	}
+	if length >= 1 {
+		name = parts[0]
+	}
+	if length == 2 {
+		var err error
+		build, err = strconv.Atoi(parts[1])
+		if err != nil {
+			return nil, fmt.Errorf("converting prerelease build component: %w", err)
+		}
+	}
+	if name != "" {
+		return &Prerelease{Name: name, Build: build}, nil
+	} else {
+		return nil, nil
+	}
 }
 
 // Compare returns an integer representing the precedence of two semantic versions. The result will be 0 if a == b,
@@ -104,12 +171,38 @@ func Compare(a, b *Version) int {
 		return 1
 	case a.Patch < b.Patch:
 		return -1
-	case a.Prerelease == "" && b.Prerelease != "":
+	case a.Prerelease != nil && b.Prerelease == nil:
 		return 1
-	case a.Prerelease != "" && b.Prerelease == "":
+	case a.Prerelease == nil && b.Prerelease != nil:
 		return -1
-	case a.Prerelease != "" && b.Prerelease != "":
-		return strings.Compare(a.Prerelease, b.Prerelease)
+	case a.Prerelease != nil && b.Prerelease != nil:
+		if a.Prerelease.Name == b.Prerelease.Name {
+			switch {
+			case a.Prerelease.Build > b.Prerelease.Build:
+				return 1
+			case a.Prerelease.Build < b.Prerelease.Build:
+				return -1
+			}
+			return 0
+		} else {
+			return strings.Compare(a.Prerelease.Name, b.Prerelease.Name)
+		}
+	default:
+		return 0
+	}
+}
+
+// Compare semver against a channel (branch). If the semver tier is the same tier as the channel returns 0, lower -1 and higher 1.
+func CompareChannel(s *Version, c string) int {
+	switch {
+	case s.Prerelease == nil && c == "":
+		return 0
+	case s.Prerelease == nil && c != "":
+		return 1
+	case s.Prerelease != nil && c == "":
+		return -1
+	case s.Prerelease != nil && c != "":
+		return strings.Compare(s.Prerelease.Name, c)
 	default:
 		return 0
 	}

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -23,20 +23,111 @@ func TestSemver_Compare(t *testing.T) {
 		{Version{Major: 99, Minor: 0, Patch: 0}, Version{Major: 2, Minor: 99, Patch: 99}, 1},
 		{s1: Version{Major: 1, Minor: 0, Patch: 0}, s2: Version{Major: 1, Minor: 0, Patch: 0}},
 		{s1: Version{Major: 0, Minor: 2, Patch: 0}, s2: Version{Major: 0, Minor: 1, Patch: 0}, want: 1},
-		{s1: Version{Major: 0, Minor: 2, Patch: 0, Metadata: "foo"}, s2: Version{Major: 0, Minor: 1, Patch: 0}, want: 1},
-		{s1: Version{Major: 0, Minor: 2, Patch: 0}, s2: Version{Major: 0, Minor: 1, Patch: 0, Metadata: "foo"}, want: 1},
-		{s1: Version{Major: 0, Minor: 2, Patch: 0, Prerelease: "rc"}, s2: Version{Major: 0, Minor: 1, Patch: 0}, want: 1},
-		{s1: Version{Major: 0, Minor: 2, Patch: 0, Prerelease: "rc"}, s2: Version{Major: 0, Minor: 2, Patch: 0}, want: -1},
-		{s1: Version{Major: 0, Minor: 2, Patch: 0}, s2: Version{Major: 0, Minor: 2, Patch: 0, Prerelease: "rc"}, want: 1},
-		{s1: Version{Major: 0, Minor: 2, Patch: 0, Metadata: "foo"}, s2: Version{Major: 0, Minor: 2, Patch: 0, Metadata: "bar"}, want: 0},
-		{s1: Version{Major: 0, Minor: 2, Patch: 0, Prerelease: "rc"}, s2: Version{Major: 0, Minor: 2, Patch: 0, Prerelease: "alpha"}, want: 1},
-		{s1: Version{Major: 0, Minor: 2, Patch: 0, Prerelease: "alpha"}, s2: Version{Major: 0, Minor: 2, Patch: 0, Prerelease: "beta"}, want: -1},
-		{s1: Version{Major: 0, Minor: 2, Patch: 0, Prerelease: "rc"}, s2: Version{Major: 0, Minor: 2, Patch: 0, Prerelease: "rc"}, want: 0},
+		{
+			s1:   Version{Major: 0, Minor: 2, Patch: 0, Metadata: "foo"},
+			s2:   Version{Major: 0, Minor: 1, Patch: 0},
+			want: 1,
+		},
+		{
+			s1:   Version{Major: 0, Minor: 2, Patch: 0, Metadata: "foo"},
+			s2:   Version{Major: 0, Minor: 2, Patch: 0, Metadata: "bar"},
+			want: 0,
+		},
+		{
+			s1:   Version{Major: 0, Minor: 2, Patch: 0},
+			s2:   Version{Major: 0, Minor: 1, Patch: 0, Metadata: "foo"},
+			want: 1,
+		},
+		{
+			s1:   Version{Major: 0, Minor: 2, Patch: 0},
+			s2:   Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "rc", Build: 1}},
+			want: -1,
+		},
+		{
+			s1:   Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "rc", Build: 1}},
+			s2:   Version{Major: 0, Minor: 1, Patch: 0},
+			want: 1,
+		},
+		{
+			s1:   Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "rc", Build: 2}},
+			s2:   Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "rc", Build: 1}},
+			want: 1,
+		},
+		{
+			s1:   Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "rc", Build: 1}},
+			s2:   Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "rc", Build: 2}},
+			want: -1,
+		},
+		{
+			s1:   Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "rc", Build: 2}},
+			s2:   Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "rc", Build: 2}},
+			want: 0,
+		},
+		{
+			s1:   Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "beta", Build: 1}},
+			s2:   Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "alpha", Build: 1}},
+			want: 1,
+		},
+		{
+			s1:   Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "alpha", Build: 1}},
+			s2:   Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "beta", Build: 1}},
+			want: -1,
+		},
+		{
+			s1:   Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "beta", Build: 1}},
+			s2:   Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "beta", Build: 1}},
+			want: 0,
+		},
 	}
 
-	for _, tc := range matrix {
+	for i, tc := range matrix {
 		got := Compare(&tc.s1, &tc.s2)
-		assert.Equal(got, tc.want, "semver precedence is not correct")
+		assert.Equal(got, tc.want, "semver precedence is not correct [%d]", i)
+	}
+}
+
+func TestSemver_CompareChanel(t *testing.T) {
+	assert := assertion.New(t)
+
+	type test struct {
+		s    Version
+		c    string
+		want int
+	}
+
+	matrix := []test{
+		{s: Version{Major: 1, Minor: 0, Patch: 2}, c: "", want: 0},
+		{s: Version{Major: 1, Minor: 0, Patch: 2}, c: "beta", want: 1},
+		{s: Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "alpha"}}, c: "", want: -1},
+		{s: Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "alpha"}}, c: "alpha", want: 0},
+		{s: Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "alpha"}}, c: "beta", want: -1},
+		{s: Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "beta"}}, c: "alpha", want: 1},
+	}
+
+	for i, tc := range matrix {
+		got := CompareChannel(&tc.s, tc.c)
+		assert.Equal(got, tc.want, "semver precedence is not correct [%d]", i)
+	}
+}
+
+func TestSemver_Clone(t *testing.T) {
+	assert := assertion.New(t)
+
+	tests := []*Version{
+		nil,
+		{Major: 1, Minor: 0, Patch: 0},
+		{Major: 0, Minor: 1, Patch: 0},
+		{Major: 0, Minor: 0, Patch: 1},
+		{Major: 2, Minor: 1, Patch: 0},
+		{Major: 2, Minor: 2, Patch: 1},
+		{Major: 1, Minor: 0, Patch: 0, Metadata: "metadata"},
+		{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{}},
+		{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "alpha"}},
+		{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "alpha", Build: 1}},
+	}
+
+	for i, tc := range tests {
+		assert.Equal(tc, tc.Clone(), "semver clone should be equal [%d]", i)
 	}
 }
 
@@ -56,9 +147,9 @@ func TestSemver_IsZero(t *testing.T) {
 		{Version{Major: 1, Minor: 1, Patch: 1}, false},
 	}
 
-	for _, tc := range matrix {
+	for i, tc := range matrix {
 		got := tc.semver.IsZero()
-		assert.Equal(got, tc.want, "semver has not been correctly classified as zero")
+		assert.Equal(got, tc.want, "semver has not been correctly classified as zero [%d]", i)
 	}
 }
 
@@ -72,13 +163,13 @@ func TestSemver_String(t *testing.T) {
 
 	tests := []test{
 		{Version{Major: 1, Minor: 0, Patch: 0}, "1.0.0"},
-		{Version{Major: 1, Minor: 0, Patch: 1, Prerelease: "rc"}, "1.0.1-rc"},
+		{Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "rc", Build: 1}}, "1.0.0-rc.1"},
 		{Version{Major: 1, Minor: 0, Patch: 1, Metadata: "metadata"}, "1.0.1+metadata"},
-		{Version{Major: 1, Minor: 0, Patch: 1, Prerelease: "alpha", Metadata: "metadata"}, "1.0.1-alpha+metadata"},
+		{Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "alpha", Build: 99}, Metadata: "metadata"}, "1.0.0-alpha.99+metadata"},
 	}
 
-	for _, tc := range tests {
-		assert.Equal(tc.want, tc.have.String(), "the strings should be equal")
+	for i, tc := range tests {
+		assert.Equal(tc.want, tc.have.String(), "the strings should be equal [%d]", i)
 	}
 }
 
@@ -92,16 +183,17 @@ func TestSemver_NewFromString_HappyScenario(t *testing.T) {
 
 	matrix := []test{
 		{"1.2.3", Version{Major: 1, Minor: 2, Patch: 3}},
-		{"1.2.3-rc", Version{Major: 1, Minor: 2, Patch: 3, Prerelease: "rc"}},
+		{"0.1.2-alpha", Version{Major: 0, Minor: 1, Patch: 2, Prerelease: &Prerelease{Name: "alpha", Build: 0}}},
+		{"1.0.0-rc.123", Version{Major: 1, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "rc", Build: 123}}},
 		{"1.2.3+metadata", Version{Major: 1, Minor: 2, Patch: 3, Metadata: "metadata"}},
-		{"1.2.3-rc+metadata", Version{Major: 1, Minor: 2, Patch: 3, Prerelease: "rc", Metadata: "metadata"}},
+		{"3.0.0-rc.123+metadata", Version{Major: 3, Minor: 0, Patch: 0, Prerelease: &Prerelease{Name: "rc", Build: 123}, Metadata: "metadata"}},
 	}
 
-	for _, tt := range matrix {
+	for i, tt := range matrix {
 		semver, err := NewFromString(tt.got)
-		assert.NoError(err, "should have created a semver from string")
+		assert.NoErrorf(err, "should have created a semver from string [%d]", i)
 
-		assert.Equal(tt.want, *semver, "version should be equal")
+		assert.Equal(tt.want, *semver, "version should be equal [%d]", i)
 	}
 }
 
@@ -116,29 +208,102 @@ func TestSemver_NewFromString_BadScenario(t *testing.T) {
 		"1.0.0-$@",
 	}
 
-	for _, str := range invalidStrings {
+	for i, str := range invalidStrings {
 		_, err := NewFromString(str)
-		assert.Error(err, "should have failed to create a semver from invalid string")
+		assert.Errorf(err, "should have failed to create a semver from invalid string [%d]", i)
 	}
 }
 
 func TestSemver_Bump(t *testing.T) {
 	assert := assertion.New(t)
 
-	s := &Version{Major: 0, Minor: 0, Patch: 0}
+	s := &Version{Major: 0, Minor: 1, Patch: 0}
 
 	s.BumpPatch()
-	assert.Equal(s.String(), "0.0.1", "the strings should be equal")
-	assert.Empty(s.Prerelease, "version prerelease should be empty after bump")
+	assert.Equal("0.1.1", s.String(), "the strings should be equal")
+	assert.Nil(s.Prerelease, "version prerelease should be empty after bump")
 	assert.Empty(s.Metadata, "version metadata should be empty after bump")
 
 	s.BumpMinor()
-	assert.Equal(s.String(), "0.1.0", "the strings should be equal")
-	assert.Empty(s.Prerelease, "version prerelease should be empty after bump")
+	assert.Equal("0.2.0", s.String(), "the strings should be equal")
+	assert.Nil(s.Prerelease, "version prerelease should be empty after bump")
 	assert.Empty(s.Metadata, "version metadata should be empty after bump")
 
 	s.BumpMajor()
-	assert.Equal(s.String(), "1.0.0", "the strings should be equal")
-	assert.Empty(s.Prerelease, "version prerelease should be empty after bump")
+	assert.Equal("1.0.0", s.String(), "the strings should be equal")
+	assert.Nil(s.Prerelease, "version prerelease should be empty after bump")
+	assert.Empty(s.Metadata, "version metadata should be empty after bump")
+
+	s.Prerelease = &Prerelease{Name: "beta"}
+	s.BumpMajor()
+	assert.Equal("2.0.0-beta.1", s.String(), "the strings should be equal")
+	assert.NotNil(s.Prerelease, "version prerelease should not be empty after bump")
+	assert.Empty(s.Metadata, "version metadata should be empty after bump")
+
+	// first version in new prerelease branch
+	s = &Version{Major: 0, Minor: 1, Patch: 1, Prerelease: &Prerelease{Name: "beta"}}
+	s.BumpPatch()
+	assert.Equal("0.1.2-beta.1", s.String(), "the strings should be equal")
+	assert.NotNil(s.Prerelease, "version prerelease should not be empty after bump")
+	assert.Empty(s.Metadata, "version metadata should be empty after bump")
+
+	s = &Version{Major: 0, Minor: 1, Patch: 0, Prerelease: &Prerelease{Name: "beta"}}
+	s.BumpMinor()
+	assert.Equal("0.2.0-beta.1", s.String(), "the strings should be equal")
+	assert.NotNil(s.Prerelease, "version prerelease should not be empty after bump")
+	assert.Empty(s.Metadata, "version metadata should be empty after bump")
+
+	s = &Version{Major: 0, Minor: 1, Patch: 1, Prerelease: &Prerelease{Name: "beta"}}
+	s.BumpMinor()
+	assert.Equal("0.2.0-beta.1", s.String(), "the strings should be equal")
+	assert.NotNil(s.Prerelease, "version prerelease should not be empty after bump")
+	assert.Empty(s.Metadata, "version metadata should be empty after bump")
+
+	s = &Version{Major: 0, Minor: 1, Patch: 1, Prerelease: &Prerelease{Name: "beta"}}
+	s.BumpMajor()
+	assert.Equal("1.0.0-beta.1", s.String(), "the strings should be equal")
+	assert.NotNil(s.Prerelease, "version prerelease should not be empty after bump")
+	assert.Empty(s.Metadata, "version metadata should be empty after bump")
+
+	// prerelease branch version bumps
+	s = &Version{Major: 0, Minor: 1, Patch: 1, Prerelease: &Prerelease{Name: "alpha", Build: 4}}
+	s.BumpPatch()
+	assert.Equal("0.1.1-alpha.5", s.String(), "the strings should be equal")
+	assert.NotNil(s.Prerelease, "version prerelease should not be empty after bump")
+	assert.Empty(s.Metadata, "version metadata should be empty after bump")
+
+	s.BumpMinor()
+	assert.Equal("0.2.0-alpha.1", s.String(), "the strings should be equal")
+	assert.NotNil(s.Prerelease, "version prerelease should not be empty after bump")
+	assert.Empty(s.Metadata, "version metadata should be empty after bump")
+
+	s.BumpMinor()
+	assert.Equal("0.2.0-alpha.2", s.String(), "the strings should be equal")
+	assert.NotNil(s.Prerelease, "version prerelease should not be empty after bump")
+	assert.Empty(s.Metadata, "version metadata should be empty after bump")
+
+	s.BumpPatch()
+	assert.Equal("0.2.0-alpha.3", s.String(), "the strings should be equal")
+	assert.NotNil(s.Prerelease, "version prerelease should not be empty after bump")
+	assert.Empty(s.Metadata, "version metadata should be empty after bump")
+
+	s.BumpMajor()
+	assert.Equal("1.0.0-alpha.1", s.String(), "the strings should be equal")
+	assert.NotNil(s.Prerelease, "version prerelease should not be empty after bump")
+	assert.Empty(s.Metadata, "version metadata should be empty after bump")
+
+	s.BumpMinor()
+	assert.Equal("1.0.0-alpha.2", s.String(), "the strings should be equal")
+	assert.NotNil(s.Prerelease, "version prerelease should not be empty after bump")
+	assert.Empty(s.Metadata, "version metadata should be empty after bump")
+
+	s.BumpPatch()
+	assert.Equal("1.0.0-alpha.3", s.String(), "the strings should be equal")
+	assert.NotNil(s.Prerelease, "version prerelease should not be empty after bump")
+	assert.Empty(s.Metadata, "version metadata should be empty after bump")
+
+	s.BumpMajor()
+	assert.Equal("1.0.0-alpha.4", s.String(), "the strings should be equal")
+	assert.NotNil(s.Prerelease, "version prerelease should not be empty after bump")
 	assert.Empty(s.Metadata, "version metadata should be empty after bump")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: 
2. If the PR is unfinished, mark it as such by prefixing its title with "WIP:" https://github.com/s0ders/go-semver-release/blob/main/CONTRIBUTING.md

-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind fix
/kind feature
/kind refactor
/kind perf
/kind documentation
-->

/kind feature

#### What this PR does / why is it needed:

This PR aims to make version bumps to be handled like in other semver release projects.

#### Does this PR introduce a breaking change?

Major changes:
- `0.1.0` is the new first release version (following [initial-development-phase](https://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase))
- only one version bump per release
- prerelease channel support (following [release-workflow/pre-releases](https://semantic-release.gitbook.io/semantic-release/recipes/release-workflow/pre-releases))

Minor changes:
- branch doesn't have to be present when set in config

#### Which issue(s), if any, this PR fixes:

#### Special notes for your reviewer:

To understand the way of version bumping it might be the easiest to go through this test scenario:
https://github.com/dionysiusmarquis/go-semver-release/blob/c290080718b630925e4a3ec9b0247766b7298bb3/cmd/release_test.go#L100

The new initial version is `0.1.0`. This will ever be the fist version ("ignoring" all commit rules for the first release). Version `0.0.0` is when it would be the first release but no commit with release rule is found.

If there are multiple rules applying since the last release the highest rule will be applied. E.g. the Version is `0.1.2` and there are multiple commits including `feat:`, `fix:`, `feat:` only the highest (`feat:` in this case) will be applied once - meaning the new version would be `0.2.0`.

Prereleases now have a build number. This is to run prereleases with a separate versioning. This way it's possible to apply fixes and features to the main channel with running prereleases. Prerelease versions are based on higher tier channels and get bumped if a higher tier version passes a prerelease version.

I plan to add more edge cases to the release cmd tests. But I thought I'd already post this pr to have a look at it and verify if this is a plausible direction.