### PR TITLE
Support monorepo project dependencies

### DIFF
--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -911,7 +911,7 @@ func TestReleaseCmd_InvalidMonorepoProjects(t *testing.T) {
 	assert := assertion.New(t)
 	ctx := appcontext.New()
 
-	ctx.MonorepositoryFlag = []map[string]string{{"path": "foo"}}
+	ctx.MonorepositoryFlag = []map[string]any{{"path": "foo"}}
 
 	_, err := configureProjects(ctx)
 	assert.ErrorIs(err, monorepo.ErrNoName, "should have failed parsing project with no name")

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -138,6 +138,46 @@ monorepo:
     path: ./xyz/bar/
 ```
 
+The program can also take into consideration dependencies between projects in a monorepo. Since this program is not targeted towards a specific programming language or build system, the dependencies have to be defined in the configuratrion of this program.
+
+For example, if the project `bar` depends on the project `foo`, the configuration can be written as follows:
+
+```bash
+$ go-semver-release release <PATH> --monorepo='[{"name": "foo", "path": "./foo/"}, {"name": "bar", "path": "./bar/", "depends-on": ["foo"]}]'
+```
+```yaml
+monorepo:
+  - name: foo
+    path: ./foo/
+  - name: bar
+    path: ./xyz/bar/
+    depends-on: [foo]
+```
+
+If project `foo` is released then `bar` will be released as well, even if no changes were made to project `bar`. In this case, the minor version of `bar` will be bumped.
+
+Since very often not every project in a monorepo is released, it is also possible to mark certain projects so that there are never released formally.
+
+For example, if you do not want to create a formal release (version number) for the project `bar`, change the configuration as follows:
+
+```bash
+$ go-semver-release release <PATH> --monorepo='[{"name": "foo", "path": "./foo/", "release": "no"}, {"name": "bar", "path": "./bar/", "depends-on": ["foo"]}]'
+```
+```yaml
+monorepo:
+  - name: foo
+    path: ./foo/
+    release: no
+  - name: bar
+    path: ./xyz/bar/
+    depends-on: [foo]
+
+```
+
+In this case, the program will check if there have been any commits to the path of project `foo` (which would normally cause a release of project `foo`) since the last release of project `bar`, and if so, it will bump the version of project `bar`, but it will not create a tag for project `foo`.
+
+This mechanism also supports transitive dependencies (project `bar` depending on project `foo` depending on project `abc`).
+
 ### Tag prefix
 
 CLI flag: `--tag-prefix`

--- a/internal/monorepo/flag.go
+++ b/internal/monorepo/flag.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-type Flag []map[string]string
+type Flag []map[string]any
 
 const FlagType = "JSON string"
 
@@ -25,7 +25,7 @@ func (f *Flag) String() string {
 }
 
 func (f *Flag) Set(value string) error {
-	var temp []map[string]string
+	var temp []map[string]any
 	if err := json.Unmarshal([]byte(value), &temp); err != nil {
 		return fmt.Errorf("unmarshalling monorepo flag value: %w", err)
 	}

--- a/internal/monorepo/flag_test.go
+++ b/internal/monorepo/flag_test.go
@@ -9,7 +9,7 @@ import (
 func TestBranchFlag_String(t *testing.T) {
 	assert := assert.New(t)
 
-	monorepoConfiguration := []map[string]string{{"name": "foo", "path": "./foo/"}, {"name": "bar", "path": "./bar./"}}
+	monorepoConfiguration := []map[string]any{{"name": "foo", "path": "./foo/"}, {"name": "bar", "path": "./bar./"}}
 	monorepoConfigurationFlag := Flag(monorepoConfiguration)
 
 	var emptyFlag Flag

--- a/internal/monorepo/monorepo.go
+++ b/internal/monorepo/monorepo.go
@@ -3,6 +3,7 @@ package monorepo
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 )
 
@@ -10,16 +11,19 @@ var (
 	ErrNoProjects = errors.New("no projects found in configuration file despite operating in monorepo mode")
 	ErrNoName     = errors.New("project has no name")
 	ErrNoPath     = errors.New("project has no path")
+	ErrWrongType  = errors.New("configuration value has wrong type")
 )
 
 type Project struct {
-	Path string
-	Name string
+	Path      string
+	Name      string
+	DependsOn []string
+	Release   bool
 }
 
 // Unmarshall takes a raw Viper configuration and returns a slice of Project representing various projects in a
 // monorepo.
-func Unmarshall(input []map[string]string) ([]Project, error) {
+func Unmarshall(input []map[string]any) ([]Project, error) {
 	if len(input) == 0 {
 		return nil, ErrNoProjects
 	}
@@ -32,15 +36,47 @@ func Unmarshall(input []map[string]string) ([]Project, error) {
 		if !ok {
 			return nil, ErrNoName
 		}
+		var nameStr string
+		if nameStr, ok = name.(string); !ok {
+			return nil, ErrWrongType
+		}
 
 		path, ok := p["path"]
 		if !ok {
 			return nil, ErrNoPath
 		}
+		var pathStr string
+		if pathStr, ok = path.(string); !ok {
+			return nil, ErrWrongType
+		}
+
+		var dependsOn []string
+		if dependsOnAny, ok := p["depends-on"]; ok {
+			var dependsOnAnySlice []any
+			if dependsOnAnySlice, ok = dependsOnAny.([]any); !ok {
+				return nil, ErrWrongType
+			}
+			for _, d := range dependsOnAnySlice {
+				dependsOn = append(dependsOn, fmt.Sprintf("%v", d))
+			}
+		}
+
+		var release = true
+		if releaseAny, ok := p["release"]; ok {
+			if releaseStr, ok := releaseAny.(string); ok {
+				release = releaseStr == "true" || releaseStr == "1" || releaseStr == "yes"
+			} else if releaseBool, ok := releaseAny.(bool); ok {
+				release = releaseBool
+			} else {
+				return nil, ErrWrongType
+			}
+		}
 
 		project := Project{
-			Name: name,
-			Path: filepath.Clean(path),
+			Name:      nameStr,
+			Path:      filepath.Clean(pathStr),
+			DependsOn: dependsOn,
+			Release:   release,
 		}
 
 		projects[i] = project

--- a/internal/monorepo/monorepo_test.go
+++ b/internal/monorepo/monorepo_test.go
@@ -10,13 +10,13 @@ import (
 func TestMonorepo_Unmarshall(t *testing.T) {
 	assert := assertion.New(t)
 
-	have := []map[string]string{{"name": "bar", "path": "./bar/"}, {"name": "foo", "path": "./xyz/foo/"}}
+	have := []map[string]any{{"name": "bar", "path": "./bar/"}, {"name": "foo", "path": "./xyz/foo/"}}
 
 	localizedPath, _ := filepath.Localize("xyz/foo")
 
 	want := []Project{
-		{Name: "bar", Path: "bar"},
-		{Name: "foo", Path: localizedPath},
+		{Name: "bar", Path: "bar", Release: true},
+		{Name: "foo", Path: localizedPath, Release: true},
 	}
 
 	branches, err := Unmarshall(have)
@@ -31,15 +31,15 @@ func TestMonorepo_UnmarshallErrors(t *testing.T) {
 	assert := assertion.New(t)
 
 	type test struct {
-		have []map[string]string
+		have []map[string]any
 		want error
 	}
 
 	tests := []test{
-		{have: []map[string]string{{"path": "./foo/"}}, want: ErrNoName},
-		{have: []map[string]string{{"name": "foo"}}, want: ErrNoPath},
-		{have: []map[string]string{}, want: ErrNoProjects},
-		{have: []map[string]string{{"name": "foo", "path": "./foo/"}}, want: nil},
+		{have: []map[string]any{{"path": "./foo/"}}, want: ErrNoName},
+		{have: []map[string]any{{"name": "foo"}}, want: ErrNoPath},
+		{have: []map[string]any{}, want: ErrNoProjects},
+		{have: []map[string]any{{"name": "foo", "path": "./foo/"}}, want: nil},
 	}
 
 	for _, tc := range tests {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -533,8 +533,8 @@ func TestParser_Run_Monorepo(t *testing.T) {
 
 	th := NewTestHelper(t)
 	th.Ctx.Projects = []monorepo.Project{
-		{Name: "foo", Path: "foo"},
-		{Name: "bar", Path: "bar"},
+		{Name: "foo", Path: "foo", Release: true},
+		{Name: "bar", Path: "bar", Release: true},
 	}
 	parser := New(th.Ctx)
 
@@ -545,6 +545,8 @@ func TestParser_Run_Monorepo(t *testing.T) {
 	checkErr(t, "computing projects new semver", err)
 
 	assert.Len(output, 2, "parser run output should contain two elements")
+
+	fmt.Printf("%v", output[1].Semver)
 
 	gotSemver := []string{output[0].Semver.String(), output[1].Semver.String()}
 
@@ -598,8 +600,8 @@ func TestParser_Run_MonorepoWithPreexistingTags(t *testing.T) {
 
 	th := NewTestHelper(t)
 	th.Ctx.Projects = []monorepo.Project{
-		{Name: "foo", Path: "foo"},
-		{Name: "bar", Path: "bar"},
+		{Name: "foo", Path: "foo", Release: true},
+		{Name: "bar", Path: "bar", Release: true},
 	}
 	parser := New(th.Ctx)
 


### PR DESCRIPTION
This implements the features discussed in https://github.com/s0ders/go-semver-release/issues/177

I know that there are no tests included yet, the existing tests still work. If yo intend to merge this into main, I can work on tests. If this will stay on my own repo, I'm okay with no tests.

/kind feature